### PR TITLE
fix: HpcrTgz(), HpcrTgzEncrypted() fucntions where it generates invalid base64

### DIFF
--- a/common/encrypt/encrypt.go
+++ b/common/encrypt/encrypt.go
@@ -94,7 +94,7 @@ func EncryptPassword(password, cert string) (string, error) {
 		return "", fmt.Errorf("failed to remove file - %v", err)
 	}
 
-	return gen.EncodeToBase64(result), nil
+	return gen.EncodeToBase64([]byte(result)), nil
 }
 
 // EncryptContract - function to encrypt contract
@@ -129,7 +129,7 @@ func EncryptString(password, section string) (string, error) {
 		return "", fmt.Errorf("failed to remove temp file - %v", err)
 	}
 
-	return gen.EncodeToBase64(result), nil
+	return gen.EncodeToBase64([]byte(result)), nil
 }
 
 // EncryptFinalStr - function to get final encrypted section
@@ -199,7 +199,7 @@ func CreateSigningCert(privateKey, cacert, cakey, csrData, csrPemData string, ex
 		}
 	}
 
-	return gen.EncodeToBase64(signingCert), nil
+	return gen.EncodeToBase64([]byte(signingCert)), nil
 }
 
 // CreateCert - function to create signing certificate
@@ -236,7 +236,7 @@ func SignContract(encryptedWorkload, encryptedEnv, privateKey string) (string, e
 		return "", fmt.Errorf("failed to remove temp file - %v", err)
 	}
 
-	return gen.EncodeToBase64(workloadEnvSignature), nil
+	return gen.EncodeToBase64([]byte(workloadEnvSignature)), nil
 }
 
 // GenFinalSignedContract - function to generate the final contract

--- a/common/general/general_test.go
+++ b/common/general/general_test.go
@@ -146,7 +146,7 @@ func TestIsJson(t *testing.T) {
 
 // Testcase to check if EncodeToBase64() can encode string to base64
 func TestEncodeToBase64(t *testing.T) {
-	result := EncodeToBase64(sampleStringData)
+	result := EncodeToBase64([]byte(sampleStringData))
 
 	assert.Equal(t, result, sampleBase64Data)
 }

--- a/contract/contract.go
+++ b/contract/contract.go
@@ -34,7 +34,7 @@ func HpcrText(plainText string) (string, string, string, error) {
 		return "", "", "", fmt.Errorf(emptyParameterErrStatement)
 	}
 
-	hpcrTextStr := gen.EncodeToBase64(plainText)
+	hpcrTextStr := gen.EncodeToBase64([]byte(plainText))
 
 	return hpcrTextStr, gen.GenerateSha256(plainText), gen.GenerateSha256(hpcrTextStr), nil
 }
@@ -45,7 +45,7 @@ func HpcrJson(plainJson string) (string, string, string, error) {
 		return "", "", "", fmt.Errorf("not a JSON data")
 	}
 
-	hpcrJsonStr := gen.EncodeToBase64(plainJson)
+	hpcrJsonStr := gen.EncodeToBase64([]byte(plainJson))
 
 	return hpcrJsonStr, gen.GenerateSha256(plainJson), gen.GenerateSha256(hpcrJsonStr), nil
 }
@@ -210,7 +210,7 @@ func encryptWrapper(contract, hyperProtectOs, encryptionCertificate, privateKey,
 		return "", fmt.Errorf("failed to encrypt workload - %v", err)
 	}
 
-	updatedEnv, err := gen.KeyValueInjector(contractMap["env"].(map[string]interface{}), "signingKey", gen.EncodeToBase64(publicKey))
+	updatedEnv, err := gen.KeyValueInjector(contractMap["env"].(map[string]interface{}), "signingKey", gen.EncodeToBase64([]byte(publicKey)))
 	if err != nil {
 		return "", fmt.Errorf("failed to inject signingKey to env - %v", err)
 	}


### PR DESCRIPTION
This PR fixes the issue where the HpcrTgz() and HpcrTgzEncrypted() generates invalid base64 causing HPVS instance boot to fail.

## Fix Validation

```bash
sashwatk@li-420cce4c-2770-11b2-a85c-81c35d559774 ~ » echo "H4sIAAAAAAAA/+zSwU4DIRAGYM4+BS/QdpiFYbsnX2UYWHdTNhioNn17UzWmB42XJsZ0v8sfwn+AycQih1Q3Upbn0tL2zEtWtwYAQNZe0ngH1/kOjVHGAQISkSMFhqxBpeHmL/nGSztyVQCN23Ti4+Gn3m/3n3/5yn+ipfo6S2rDg9ZTyrlsTqXmeDlqPS/8lAb9sSPbuezyHCrX8+6q+dgmRkcDBGJAH5yMHeII+5E8kHhnE/TE2GESE2PgvnPSs3FCErxNI0TbCe7/ehCr1Wp1Z94CAAD//71/2IsACAAA" | base64 -d > test.tgz
sashwatk@li-420cce4c-2770-11b2-a85c-81c35d559774 ~ » tar -zxvf test.tgz 
docker-compose.yaml
sashwatk@li-420cce4c-2770-11b2-a85c-81c35d559774 ~ » cat docker-compose.yaml 
services:
  hello-world:
    image: docker.io/library/hello-world@sha256:0b6a027b5cf322f09f6706c754e086a232ec1ddba835c8a15c6cb74ef0d43c29
```