### PR TITLE
feat: add support for custom openssl path

### DIFF
--- a/common/decrypt/decrypt.go
+++ b/common/decrypt/decrypt.go
@@ -44,7 +44,7 @@ func DecryptPassword(base64EncryptedData, privateKey string) (string, error) {
 		return "", fmt.Errorf("failed to create temp file - %v", err)
 	}
 
-	result, err := gen.ExecCommand("", "pkeyutl", "-decrypt", "-inkey", privateKeyPath, "-in", encryptedDataPath)
+	result, err := gen.ExecCommand(gen.GetOpenSSLPath(), "", "pkeyutl", "-decrypt", "-inkey", privateKeyPath, "-in", encryptedDataPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to execute openssl command - %v", err)
 	}
@@ -76,7 +76,7 @@ func DecryptWorkload(password, encryptedWorkload string) (string, error) {
 		return "", fmt.Errorf("failed to create temp file - %v", err)
 	}
 
-	result, err := gen.ExecCommand(password, "aes-256-cbc", "-d", "-pbkdf2", "-in", encryptedDataPath, "-pass", "stdin")
+	result, err := gen.ExecCommand(gen.GetOpenSSLPath(), password, "aes-256-cbc", "-d", "-pbkdf2", "-in", encryptedDataPath, "-pass", "stdin")
 	if err != nil {
 		return "", fmt.Errorf("failed to execute openssl command - %v", err)
 	}

--- a/common/decrypt/decrypt.go
+++ b/common/decrypt/decrypt.go
@@ -44,7 +44,7 @@ func DecryptPassword(base64EncryptedData, privateKey string) (string, error) {
 		return "", fmt.Errorf("failed to create temp file - %v", err)
 	}
 
-	result, err := gen.ExecCommand("openssl", "", "pkeyutl", "-decrypt", "-inkey", privateKeyPath, "-in", encryptedDataPath)
+	result, err := gen.ExecCommand("", "pkeyutl", "-decrypt", "-inkey", privateKeyPath, "-in", encryptedDataPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to execute openssl command - %v", err)
 	}
@@ -76,7 +76,7 @@ func DecryptWorkload(password, encryptedWorkload string) (string, error) {
 		return "", fmt.Errorf("failed to create temp file - %v", err)
 	}
 
-	result, err := gen.ExecCommand("openssl", password, "aes-256-cbc", "-d", "-pbkdf2", "-in", encryptedDataPath, "-pass", "stdin")
+	result, err := gen.ExecCommand(password, "aes-256-cbc", "-d", "-pbkdf2", "-in", encryptedDataPath, "-pass", "stdin")
 	if err != nil {
 		return "", fmt.Errorf("failed to execute openssl command - %v", err)
 	}

--- a/common/encrypt/encrypt.go
+++ b/common/encrypt/encrypt.go
@@ -28,7 +28,7 @@ const (
 
 // OpensslCheck - function to check if openssl exists
 func OpensslCheck() error {
-	_, err := gen.ExecCommand("openssl", "", "version")
+	_, err := gen.ExecCommand("", "version")
 
 	if err != nil {
 		return err
@@ -49,7 +49,7 @@ func GeneratePublicKey(privateKey string) (string, error) {
 		return "", fmt.Errorf("failed to create temp file - %v", err)
 	}
 
-	publicKey, err := gen.ExecCommand("openssl", "", "rsa", "-in", privateKeyPath, "-pubout")
+	publicKey, err := gen.ExecCommand("", "rsa", "-in", privateKeyPath, "-pubout")
 	if err != nil {
 		return "", fmt.Errorf("failed to execute openssl command - %v", err)
 	}
@@ -64,7 +64,7 @@ func RandomPasswordGenerator() (string, error) {
 		return "", fmt.Errorf("openssl not found - %v", err)
 	}
 
-	randomPassword, err := gen.ExecCommand("openssl", "", "rand", fmt.Sprint(keylen))
+	randomPassword, err := gen.ExecCommand("", "rand", fmt.Sprint(keylen))
 	if err != nil {
 		return "", fmt.Errorf("failed to execute openssl command - %v", err)
 	}
@@ -84,7 +84,7 @@ func EncryptPassword(password, cert string) (string, error) {
 		return "", fmt.Errorf("failed to create temp file - %v", err)
 	}
 
-	result, err := gen.ExecCommand("openssl", password, "rsautl", "-encrypt", "-inkey", encryptCertPath, "-certin")
+	result, err := gen.ExecCommand(password, "rsautl", "-encrypt", "-inkey", encryptCertPath, "-certin")
 	if err != nil {
 		return "", fmt.Errorf("failed to execute openssl command - %v", err)
 	}
@@ -119,7 +119,7 @@ func EncryptString(password, section string) (string, error) {
 		return "", fmt.Errorf("failed to create temp file - %v", err)
 	}
 
-	result, err := gen.ExecCommand("openssl", password, "enc", "-aes-256-cbc", "-pbkdf2", "-pass", "stdin", "-in", contractPath)
+	result, err := gen.ExecCommand(password, "enc", "-aes-256-cbc", "-pbkdf2", "-pass", "stdin", "-in", contractPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to execute openssl command - %v", err)
 	}
@@ -159,7 +159,7 @@ func CreateSigningCert(privateKey, cacert, cakey, csrData, csrPemData string, ex
 
 		csrParam := fmt.Sprintf("/C=%s/ST=%s/L=%s/O=%s/OU=%s/CN=%sC/emailAddress=%s", csrDataMap["country"], csrDataMap["state"], csrDataMap["location"], csrDataMap["org"], csrDataMap["unit"], csrDataMap["domain"], csrDataMap["mail"])
 
-		csr, err = gen.ExecCommand("openssl", "", "req", "-new", "-key", privateKeyPath, "-subj", csrParam)
+		csr, err = gen.ExecCommand("", "req", "-new", "-key", privateKeyPath, "-subj", csrParam)
 		if err != nil {
 			return "", fmt.Errorf("failed to execute openssl command - %v", err)
 		}
@@ -204,7 +204,7 @@ func CreateSigningCert(privateKey, cacert, cakey, csrData, csrPemData string, ex
 
 // CreateCert - function to create signing certificate
 func CreateCert(csrPath, caCertPath, caKeyPath string, expiryDays int) (string, error) {
-	signingCert, err := gen.ExecCommand("openssl", "", "x509", "-req", "-in", csrPath, "-CA", caCertPath, "-CAkey", caKeyPath, "-CAcreateserial", "-days", fmt.Sprintf("%d", expiryDays))
+	signingCert, err := gen.ExecCommand("", "x509", "-req", "-in", csrPath, "-CA", caCertPath, "-CAkey", caKeyPath, "-CAcreateserial", "-days", fmt.Sprintf("%d", expiryDays))
 	if err != nil {
 		return "", fmt.Errorf("failed to execute openssl command - %v", err)
 	}
@@ -226,7 +226,7 @@ func SignContract(encryptedWorkload, encryptedEnv, privateKey string) (string, e
 		return "", fmt.Errorf("failed to create temp file - %v", err)
 	}
 
-	workloadEnvSignature, err := gen.ExecCommand("openssl", combinedContract, "dgst", "-sha256", "-sign", privateKeyPath)
+	workloadEnvSignature, err := gen.ExecCommand(combinedContract, "dgst", "-sha256", "-sign", privateKeyPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to execute openssl command - %v", err)
 	}

--- a/common/encrypt/encrypt.go
+++ b/common/encrypt/encrypt.go
@@ -28,7 +28,7 @@ const (
 
 // OpensslCheck - function to check if openssl exists
 func OpensslCheck() error {
-	_, err := gen.ExecCommand("", "version")
+	_, err := gen.ExecCommand(gen.GetOpenSSLPath(), "", "version")
 
 	if err != nil {
 		return err
@@ -49,7 +49,7 @@ func GeneratePublicKey(privateKey string) (string, error) {
 		return "", fmt.Errorf("failed to create temp file - %v", err)
 	}
 
-	publicKey, err := gen.ExecCommand("", "rsa", "-in", privateKeyPath, "-pubout")
+	publicKey, err := gen.ExecCommand(gen.GetOpenSSLPath(), "", "rsa", "-in", privateKeyPath, "-pubout")
 	if err != nil {
 		return "", fmt.Errorf("failed to execute openssl command - %v", err)
 	}
@@ -64,7 +64,7 @@ func RandomPasswordGenerator() (string, error) {
 		return "", fmt.Errorf("openssl not found - %v", err)
 	}
 
-	randomPassword, err := gen.ExecCommand("", "rand", fmt.Sprint(keylen))
+	randomPassword, err := gen.ExecCommand(gen.GetOpenSSLPath(), "", "rand", fmt.Sprint(keylen))
 	if err != nil {
 		return "", fmt.Errorf("failed to execute openssl command - %v", err)
 	}
@@ -84,7 +84,7 @@ func EncryptPassword(password, cert string) (string, error) {
 		return "", fmt.Errorf("failed to create temp file - %v", err)
 	}
 
-	result, err := gen.ExecCommand(password, "rsautl", "-encrypt", "-inkey", encryptCertPath, "-certin")
+	result, err := gen.ExecCommand(gen.GetOpenSSLPath(), password, "rsautl", "-encrypt", "-inkey", encryptCertPath, "-certin")
 	if err != nil {
 		return "", fmt.Errorf("failed to execute openssl command - %v", err)
 	}
@@ -119,7 +119,7 @@ func EncryptString(password, section string) (string, error) {
 		return "", fmt.Errorf("failed to create temp file - %v", err)
 	}
 
-	result, err := gen.ExecCommand(password, "enc", "-aes-256-cbc", "-pbkdf2", "-pass", "stdin", "-in", contractPath)
+	result, err := gen.ExecCommand(gen.GetOpenSSLPath(), password, "enc", "-aes-256-cbc", "-pbkdf2", "-pass", "stdin", "-in", contractPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to execute openssl command - %v", err)
 	}
@@ -159,7 +159,7 @@ func CreateSigningCert(privateKey, cacert, cakey, csrData, csrPemData string, ex
 
 		csrParam := fmt.Sprintf("/C=%s/ST=%s/L=%s/O=%s/OU=%s/CN=%sC/emailAddress=%s", csrDataMap["country"], csrDataMap["state"], csrDataMap["location"], csrDataMap["org"], csrDataMap["unit"], csrDataMap["domain"], csrDataMap["mail"])
 
-		csr, err = gen.ExecCommand("", "req", "-new", "-key", privateKeyPath, "-subj", csrParam)
+		csr, err = gen.ExecCommand(gen.GetOpenSSLPath(), "", "req", "-new", "-key", privateKeyPath, "-subj", csrParam)
 		if err != nil {
 			return "", fmt.Errorf("failed to execute openssl command - %v", err)
 		}
@@ -204,7 +204,7 @@ func CreateSigningCert(privateKey, cacert, cakey, csrData, csrPemData string, ex
 
 // CreateCert - function to create signing certificate
 func CreateCert(csrPath, caCertPath, caKeyPath string, expiryDays int) (string, error) {
-	signingCert, err := gen.ExecCommand("", "x509", "-req", "-in", csrPath, "-CA", caCertPath, "-CAkey", caKeyPath, "-CAcreateserial", "-days", fmt.Sprintf("%d", expiryDays))
+	signingCert, err := gen.ExecCommand(gen.GetOpenSSLPath(), "", "x509", "-req", "-in", csrPath, "-CA", caCertPath, "-CAkey", caKeyPath, "-CAcreateserial", "-days", fmt.Sprintf("%d", expiryDays))
 	if err != nil {
 		return "", fmt.Errorf("failed to execute openssl command - %v", err)
 	}
@@ -226,7 +226,7 @@ func SignContract(encryptedWorkload, encryptedEnv, privateKey string) (string, e
 		return "", fmt.Errorf("failed to create temp file - %v", err)
 	}
 
-	workloadEnvSignature, err := gen.ExecCommand(combinedContract, "dgst", "-sha256", "-sign", privateKeyPath)
+	workloadEnvSignature, err := gen.ExecCommand(gen.GetOpenSSLPath(), combinedContract, "dgst", "-sha256", "-sign", privateKeyPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to execute openssl command - %v", err)
 	}

--- a/common/general/general.go
+++ b/common/general/general.go
@@ -60,7 +60,10 @@ func CheckIfEmpty(values ...interface{}) bool {
 	return empty
 }
 
-func getOpenSSLPath() string {
+// GetOpenSSLPath check if OPENSSL_BIN is set
+// If set → returns its value
+// If not set → defaults to "openssl"
+func GetOpenSSLPath() string {
 	if envPath := os.Getenv("OPENSSL_BIN"); envPath != "" {
 		return envPath
 	}
@@ -68,8 +71,8 @@ func getOpenSSLPath() string {
 }
 
 // ExecCommand - function to run os commands
-func ExecCommand(stdinInput string, args ...string) (string, error) {
-	cmd := exec.Command(getOpenSSLPath(), args...)
+func ExecCommand(commandName, stdinInput string, args ...string) (string, error) {
+	cmd := exec.Command(commandName, args...)
 
 	// Check for standard input
 	if stdinInput != "" {

--- a/common/general/general.go
+++ b/common/general/general.go
@@ -60,9 +60,16 @@ func CheckIfEmpty(values ...interface{}) bool {
 	return empty
 }
 
+func getOpenSSLPath() string {
+	if envPath := os.Getenv("OPENSSL_BIN"); envPath != "" {
+		return envPath
+	}
+	return "openssl"
+}
+
 // ExecCommand - function to run os commands
-func ExecCommand(name string, stdinInput string, args ...string) (string, error) {
-	cmd := exec.Command(name, args...)
+func ExecCommand(stdinInput string, args ...string) (string, error) {
+	cmd := exec.Command(getOpenSSLPath(), args...)
 
 	// Check for standard input
 	if stdinInput != "" {

--- a/common/general/general_test.go
+++ b/common/general/general_test.go
@@ -60,7 +60,7 @@ func TestCheckIfEmpty(t *testing.T) {
 
 // Testcase to check ExecCommand() works
 func TestExecCommand(t *testing.T) {
-	_, err := ExecCommand("", "version")
+	_, err := ExecCommand("openssl", "", "version")
 	if err != nil {
 		t.Errorf("failed to execute command - %v", err)
 	}
@@ -68,7 +68,7 @@ func TestExecCommand(t *testing.T) {
 
 // Testcase to check ExecCommand() when user input is given
 func TestExecCommandUserInput(t *testing.T) {
-	_, err := ExecCommand("hello", "version")
+	_, err := ExecCommand("openssl", "hello", "version")
 	if err != nil {
 		t.Errorf("failed to execute command - %v", err)
 	}
@@ -343,7 +343,7 @@ func TestGetOpenSSLPath_WithEnvVarSet(t *testing.T) {
 	os.Setenv("OPENSSL_BIN", expectedPath)
 	defer os.Unsetenv("OPENSSL_BIN")
 
-	result := getOpenSSLPath()
+	result := GetOpenSSLPath()
 	if result != expectedPath {
 		t.Errorf("expected %s, got %s", expectedPath, result)
 	}
@@ -355,7 +355,7 @@ func TestGetOpenSSLPath_WithoutEnvVarSet(t *testing.T) {
 	// Ensure env variable is not set
 	os.Unsetenv("OPENSSL_BIN")
 
-	result := getOpenSSLPath()
+	result := GetOpenSSLPath()
 	expected := "openssl"
 
 	if result != expected {

--- a/common/general/general_test.go
+++ b/common/general/general_test.go
@@ -17,6 +17,7 @@ package general
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -59,7 +60,7 @@ func TestCheckIfEmpty(t *testing.T) {
 
 // Testcase to check ExecCommand() works
 func TestExecCommand(t *testing.T) {
-	_, err := ExecCommand("openssl", "", "version")
+	_, err := ExecCommand("", "version")
 	if err != nil {
 		t.Errorf("failed to execute command - %v", err)
 	}
@@ -67,7 +68,7 @@ func TestExecCommand(t *testing.T) {
 
 // Testcase to check ExecCommand() when user input is given
 func TestExecCommandUserInput(t *testing.T) {
-	_, err := ExecCommand("openssl", "hello", "version")
+	_, err := ExecCommand("hello", "version")
 	if err != nil {
 		t.Errorf("failed to execute command - %v", err)
 	}
@@ -331,4 +332,33 @@ func TestFetchContractSchemaRhvs(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, result)
+}
+
+// TestGetOpenSSLPath_WithEnvVarSet tests the case when the OPENSSL_BIN environment variable is set.
+// It should return the value of the environment variable instead of the default "openssl".
+func TestGetOpenSSLPath_WithEnvVarSet(t *testing.T) {
+	expectedPath := "/usr/bin/openssl"
+
+	// Set the environment variable
+	os.Setenv("OPENSSL_BIN", expectedPath)
+	defer os.Unsetenv("OPENSSL_BIN")
+
+	result := getOpenSSLPath()
+	if result != expectedPath {
+		t.Errorf("expected %s, got %s", expectedPath, result)
+	}
+}
+
+// TestGetOpenSSLPath_WithoutEnvVarSet tests the fallback case when OPENSSL_BIN is not set.
+// It should return the default command name "openssl".
+func TestGetOpenSSLPath_WithoutEnvVarSet(t *testing.T) {
+	// Ensure env variable is not set
+	os.Unsetenv("OPENSSL_BIN")
+
+	result := getOpenSSLPath()
+	expected := "openssl"
+
+	if result != expected {
+		t.Errorf("expected %s, got %s", expected, result)
+	}
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,28 @@
 The library has been developed to automate the process for provisioning Hyper Protect Virtual Servers for VPC and Hyper Protect Container Runtime.
 
 
+## Configuration
+
+##### `OPENSSL_BIN` (optional)
+
+You can configure the path to the `openssl` binary using the `OPENSSL_BIN` environment variable.
+
+This is useful especially on systems where `openssl` is not available in the system `PATH` (e.g., on Windows).
+
+#### Usage:
+
+Set the `OPENSSL_BIN` environment variable to the full path of your `openssl` executable.
+
+##### On Linux/macOS:
+
+```bash
+export OPENSSL_BIN=/usr/bin/openssl
+```
+On Windows (PowerShell):
+```bash
+$env:OPENSSL_BIN="C:\Program Files\OpenSSL-Win64\bin\openssl.exe"
+```
+
 ## Usage
 
 ### HpcrGetAttestationRecords()

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
-github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Description

This PR introduces a getOpenSSLPath() function that allows the application to use a custom path to the OpenSSL binary via the OPENSSL_BIN environment variable. If the variable is not set, it gracefully falls back to using "openssl" (assuming it's available in the system PATH).

Details:
 - Added `getOpenSSLPath()` function
  
 - Checks if OPENSSL_BIN is set
  
     - If set → returns its value
  
     - If not set → defaults to "openssl"

Motivation:

On platforms like Windows, OpenSSL is often not in the system PATH. This change makes the tool more portable and user-friendly by supporting configurable paths for OpenSSL.

Test results:
```
go test ./...
?       github.com/ibm-hyper-protect/contract-go/encryption     [no test files]
?       github.com/ibm-hyper-protect/contract-go/schema [no test files]
ok      github.com/ibm-hyper-protect/contract-go/attestation    1.272s
ok      github.com/ibm-hyper-protect/contract-go/certificate    11.733s
ok      github.com/ibm-hyper-protect/contract-go/common/decrypt 2.146s
ok      github.com/ibm-hyper-protect/contract-go/common/encrypt 6.799s
ok      github.com/ibm-hyper-protect/contract-go/common/general 4.181s
ok      github.com/ibm-hyper-protect/contract-go/contract       3.253s
ok      github.com/ibm-hyper-protect/contract-go/image  3.074s
```


## Checklist

- [x] I have opened an issue for this change
- [x] The issue has been approved by a maintainer
- [x] I have added tests or explained on feature / bug
- [x] I have run `make tidy`, `make test` and it passes

Closes: https://github.com/ibm-hyper-protect/contract-go/issues/110
