### PR TITLE
fix: Update error message and add testcases for network config verification

### DIFF
--- a/common/general/general.go
+++ b/common/general/general.go
@@ -483,7 +483,7 @@ func VerifyNetworkSchema(Network_Config_File string) error {
 	}
 
 	if err := sch.Validate(data); err != nil {
-		return fmt.Errorf("contract validation failed - %v", err)
+		return fmt.Errorf("network schema verification failed - %v", err)
 	}
 
 	return nil

--- a/common/general/general_test.go
+++ b/common/general/general_test.go
@@ -34,6 +34,9 @@ const (
 	simpleContractPath        = "../../samples/simple_contract.yaml"
 	simpleInvalidContractPath = "../../samples/simple_contract_invalid.yaml"
 
+	simpleNetworkConfigPath        = "../../samples/network/network_config.yaml"
+	simpleInvalidNetworkConfigPath = "../../samples/network/network_config_invalid.yaml"
+
 	simpleWorkloadPath = "../../samples/workload.yaml"
 
 	certificateDownloadUrl = "https://cloud.ibm.com/media/docs/downloads/hyper-protect-container-runtime/ibm-hyper-protect-container-runtime-1-0-s390x-15-encrypt.crt"
@@ -357,4 +360,42 @@ func TestGetOpenSSLPath_WithoutEnvVarSet(t *testing.T) {
 	if result != expected {
 		t.Errorf("expected %s, got %s", expected, result)
 	}
+}
+
+// Testcase to check if VerifyNetworkSchema() is able to verify schema of network-config
+func TestVerifyNetworkSchema(t *testing.T) {
+	network, err := ReadDataFromFile(simpleNetworkConfigPath)
+	if err != nil {
+		t.Errorf("failed to read network config file - %v", err)
+	}
+
+	err = VerifyNetworkSchema(network)
+
+	assert.NoError(t, err)
+}
+
+// Testcase to check if VerifyNetworkSchema() is able to throw error for invalid network-config
+func TestVerifyNetworkSchemaInvalid(t *testing.T) {
+	network, err := ReadDataFromFile(simpleInvalidNetworkConfigPath)
+	if err != nil {
+		t.Errorf("failed to read network config file - %v", err)
+	}
+
+	err = VerifyNetworkSchema(network)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "additionalProperties 'enc' not allowed")
+}
+
+// Testcase to check if yamlParse() is able to unmarshell the YAML file
+func TestNetworkConfigYamlParse(t *testing.T) {
+	network, err := ReadDataFromFile(simpleInvalidNetworkConfigPath)
+	if err != nil {
+		t.Errorf("failed to read network config file - %v", err)
+	}
+	result, err := yamlParse(network)
+	if err != nil {
+		t.Errorf("failed to unmarshell the YAML file - %v", err)
+	}
+
+	assert.NotEmpty(t, result)
 }

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -31,7 +31,7 @@ const (
 func TestProcessNetworkSchemaValid(t *testing.T) {
 	network_config, err := gen.ReadDataFromFile(validNetworkConfigFile)
 	if err != nil {
-		t.Errorf("failed to read encrypted checksum - %v", err)
+		t.Errorf("failed to read network config file - %v", err)
 	}
 	err = HpcrVerifyNetworkConfig(network_config)
 	assert.NoError(t, err)
@@ -41,7 +41,7 @@ func TestProcessNetworkSchemaValid(t *testing.T) {
 func TestProcessNetworkSchemaInvalid(t *testing.T) {
 	network_config_invalid, err := gen.ReadDataFromFile(invalidNetworkConfigFile)
 	if err != nil {
-		t.Errorf("failed to read encrypted checksum - %v", err)
+		t.Errorf("failed to read network config file - %v", err)
 	}
 	err = HpcrVerifyNetworkConfig(network_config_invalid)
 	assert.Error(t, err)


### PR DESCRIPTION
## Description

- update error message that referenced contract instead of network-config
- add tests for VerifyNetworkSchema and yamlParse to improve coverage

## Checklist

- [ ] I have opened an issue for this change
- [ ] The issue has been approved by a maintainer
- [x] I have added tests or explained on feature / bug
- [x] I have run `make tidy`, `make test` and it passes

Closes: #[ISSUE_NUMBER]
