### PR TITLE
test: fixing TestHpcrContractSignedEncrypted testcase

### DIFF
--- a/contract/contract_test.go
+++ b/contract/contract_test.go
@@ -17,7 +17,6 @@ package contract
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"testing"
 
@@ -200,11 +199,10 @@ func TestHpcrVerifyContract(t *testing.T) {
 
 // Testcase to check if HpcrContractSignedEncrypted() is able to generate
 func TestHpcrContractSignedEncrypted(t *testing.T) {
-	encryption_cert := "../encryption/ibm-hyper-protect-container-runtime-1-0-s390x-24-encrypt.crt"
+	encryption_cert := "../encryption/ibm-hyper-protect-container-runtime-1-0-s390x-25-encrypt.crt"
 	data, err := os.ReadFile(encryption_cert)
 	if err != nil {
-		fmt.Println("Error reading file:", err)
-		return
+		t.Errorf("Error reading file: - %v", err)
 	}
 	contract, privateKey, _, _, _, err := common(t.Name())
 	if err != nil {


### PR DESCRIPTION
## Description
Fixed TestHpcrContractSignedEncrypted testcases as earlier testcase is not failing if encryption cert is not present in given directory in testcase.

With present changes:
```
=== RUN   TestHpcrContractSignedEncrypted
Error reading file: open ../encryption/ibm-hyper-protect-container-runtime-1-0-s390x-24-encrypt.crt: no such file or directory
--- PASS: TestHpcrContractSignedEncrypted (0.00s)
```

Testcase passed but ideally it should failed as encryption cert is not present in given location.

With this change:

```
--- FAIL: TestHpcrContractSignedEncrypted (0.23s)
    /Users/vikassharma/Documents/opensource/contract-go/contract/contract_test.go:205: Error reading file: - open ../encryption/ibm-hyper-protect-container-runtime-1-0-s390x-24-encrypt.crt: no such file or directory
FAIL
FAIL	github.com/ibm-hyper-protect/contract-go/v2/contract	0.971s
FAIL
```

Now testcase failed as given cert is not present.


## Related Issue
Fixes #issue_number

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactor

## Testing
Describe the tests you ran and how to reproduce them

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
