### PR TITLE
feat: add support to get expiry dates of encryption certificates

### DIFF
--- a/certificate/certificate.go
+++ b/certificate/certificate.go
@@ -52,13 +52,20 @@ type CertSpec struct {
 // Returns:
 //   - Version string of the extracted certificate
 //   - PEM-formatted encryption certificate
+//   - Expiry date of the encryption certificate
+//   - Expiry days of the encryption certificate
+//   - Status of the Encryption certificate
 //   - Error if version not found or data is invalid
-func HpcrGetEncryptionCertificateFromJson(encryptionCertificateJson, version string) (string, string, error) {
+func HpcrGetEncryptionCertificateFromJson(encryptionCertificateJson, version string) (string, string, string, string, string, error) {
 	if gen.CheckIfEmpty(encryptionCertificateJson, version) {
-		return "", "", fmt.Errorf(missingParameterErrStatement)
+		return "", "", "", "", "", fmt.Errorf(missingParameterErrStatement)
 	}
 
-	return gen.GetDataFromLatestVersion(encryptionCertificateJson, version)
+	latestVersion, certInfo, err := gen.GetDataFromLatestVersion(encryptionCertificateJson, version)
+	if err != nil {
+		return "", "", "", "", "", fmt.Errorf("failed to get latest version - %v", err)
+	}
+	return latestVersion, certInfo["cert"], certInfo["expiry_date"], certInfo["expiry_days"], certInfo["status"], nil
 }
 
 // HpcrDownloadEncryptionCertificates downloads encryption certificates for specified HPCR versions from IBM Cloud.

--- a/certificate/certificate_test.go
+++ b/certificate/certificate_test.go
@@ -46,13 +46,16 @@ var (
 func TestGetEncryptionCertificateFromJson(t *testing.T) {
 	version := "> 1.0.0"
 
-	key, value, err := HpcrGetEncryptionCertificateFromJson(sampleJsonData, version)
+	key, cert, expiry_date, expiry_days, status, err := HpcrGetEncryptionCertificateFromJson(sampleJsonData, version)
 	if err != nil {
 		t.Errorf("failed to get encryption certificate from JSON - %v", err)
 	}
 
 	assert.Equal(t, key, "4.0.0")
-	assert.Equal(t, value, "data2")
+	assert.Equal(t, cert, "data2")
+	assert.Equal(t, expiry_date, "26-02-26 12:27:33 GMT")
+	assert.Equal(t, expiry_days, "2")
+	assert.Equal(t, status, "test2")
 }
 
 // Testcase to check if DownloadEncryptionCertificates() is able to download encryption certificates as per constraint
@@ -96,7 +99,7 @@ func TestCombined(t *testing.T) {
 
 	version := "> 1.0.20"
 
-	key, _, err := HpcrGetEncryptionCertificateFromJson(certs, version)
+	key, _, _, _, _, err := HpcrGetEncryptionCertificateFromJson(certs, version)
 	if err != nil {
 		t.Errorf("failed to get encryption certificate from JSON - %v", err)
 	}

--- a/common/general/general.go
+++ b/common/general/general.go
@@ -427,7 +427,7 @@ func CheckUrlExists(url string) (bool, error) {
 
 // GetDataFromLatestVersion retrieves the latest version data matching semantic version constraints.
 // It parses JSON data containing version-keyed maps, applies version constraints,
-// and returns the certificate for the latest matching version.
+// and returns the certificate info for the latest matching version.
 //
 // Parameters:
 //   - jsonData: JSON string containing version-to-data mappings
@@ -435,17 +435,17 @@ func CheckUrlExists(url string) (bool, error) {
 //
 // Returns:
 //   - Latest matching version string
-//   - Certificate data for the matching version
+//   - Certificate data info for the matching version
 //   - Error if JSON parsing, version constraint parsing, or no match found
-func GetDataFromLatestVersion(jsonData, version string) (string, string, error) {
+func GetDataFromLatestVersion(jsonData, version string) (string, map[string]string, error) {
 	var dataMap map[string]map[string]string
 	if err := json.Unmarshal([]byte(jsonData), &dataMap); err != nil {
-		return "", "", fmt.Errorf("error unmarshaling JSON data - %v", err)
+		return "", nil, fmt.Errorf("error unmarshaling JSON data - %v", err)
 	}
 
 	targetConstraint, err := semver.NewConstraint(version)
 	if err != nil {
-		return "", "", fmt.Errorf("error parsing target version constraint - %v", err)
+		return "", nil, fmt.Errorf("error parsing target version constraint - %v", err)
 	}
 
 	var matchingVersions []*semver.Version
@@ -453,7 +453,7 @@ func GetDataFromLatestVersion(jsonData, version string) (string, string, error) 
 	for versionStr := range dataMap {
 		version, err := semver.NewVersion(versionStr)
 		if err != nil {
-			return "", "", fmt.Errorf("error parsing version - %v", err)
+			return "", nil, fmt.Errorf("error parsing version - %v", err)
 		}
 
 		if targetConstraint.Check(version) {
@@ -466,11 +466,11 @@ func GetDataFromLatestVersion(jsonData, version string) (string, string, error) 
 	// Get the latest version and its corresponding data
 	if len(matchingVersions) > 0 {
 		latestVersion := matchingVersions[0]
-		return latestVersion.String(), dataMap[latestVersion.String()]["cert"], nil
+		return latestVersion.String(), dataMap[latestVersion.String()], nil
 	}
 
 	// No matching version found
-	return "", "", fmt.Errorf("no matching version found for the given constraint")
+	return "", nil, fmt.Errorf("no matching version found for the given constraint")
 }
 
 // FetchEncryptionCertificate retrieves the appropriate encryption certificate for a Hyper Protect platform.

--- a/common/general/general_test.go
+++ b/common/general/general_test.go
@@ -18,6 +18,7 @@ package general
 import (
 	"bytes"
 	"compress/gzip"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -259,13 +260,18 @@ func TestCheckUrlExists(t *testing.T) {
 func TestGetDataFromLatestVersion(t *testing.T) {
 	versionConstraints := ">= 1.0.0, <= 3.5.10"
 
-	key, value, err := GetDataFromLatestVersion(sampleCertificateJson, versionConstraints)
-	if err != nil {
-		t.Errorf("failed to get encryption certificate - %v", err)
+	var data map[string]map[string]string
+	if err := json.Unmarshal([]byte(sampleCertificateJson), &data); err != nil {
+		t.Fatalf("bad certificate JSON: %v", err)
 	}
 
-	assert.Equal(t, key, "3.5.10")
-	assert.Equal(t, value, "data4")
+	key, certInfo, err := GetDataFromLatestVersion(sampleCertificateJson, versionConstraints)
+	if err != nil {
+		t.Fatalf("failed to get encryption certificate - %v", err)
+	}
+
+	assert.Equal(t, "3.5.10", key)
+	assert.Equal(t, data[key], certInfo)
 }
 
 // Testcase to check if FetchEncryptionCertificate() fetches encryption certificate for HPVS

--- a/docs/README.md
+++ b/docs/README.md
@@ -191,7 +191,7 @@ Extracts a specific version's encryption certificate from the output of `HpcrDow
 
 **Signature:**
 ```go
-func HpcrGetEncryptionCertificateFromJson(encryptionCertificateJson, version string) (string, string, error)
+func HpcrGetEncryptionCertificateFromJson(encryptionCertificateJson, version string) (string, string, string, string, string, error)
 ```
 
 **Parameters:**
@@ -207,6 +207,9 @@ func HpcrGetEncryptionCertificateFromJson(encryptionCertificateJson, version str
 |--------|------|-------------|
 | Version | `string` | The requested version number |
 | Certificate | `string` | PEM-formatted encryption certificate |
+| Expiry date |  `string` | Expiry date of encryption certificate |
+| Expiry Days | `string` | Expiry days of encryption certificate |
+| Status | `string` | Status of encryption certificate |
 | Error | `error` | Error if version not found or JSON invalid |
 
 **Example:**
@@ -229,13 +232,16 @@ func main() {
     }
 
     // Extract specific version
-    version, cert, err := certificate.HpcrGetEncryptionCertificateFromJson(certsJSON, "1.1.15")
+    version, cert, expiry_date, expiry_days, status, err := certificate.HpcrGetEncryptionCertificateFromJson(certsJSON, "1.1.15")
     if err != nil {
         log.Fatalf("Failed to get certificate: %v", err)
     }
 
     fmt.Printf("Version: %s\n", version)
     fmt.Printf("Certificate:\n%s\n", cert)
+    fmt.Printf("Expiry date:\n%s\n", expiry_date)
+    fmt.Printf("Expiry days:\n%s\n", expiry_days)
+    fmt.Printf("status:\n%s\n", status)
 }
 ```
 


### PR DESCRIPTION
## Description
This change help to get encryption cert details like expiry date, expiry days, status of certificate.

## Related Issue
Fixes #168 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code refactor

## Testing
Tested changes with contract-cli updated get-certificate command:

```
vikassharma@Vikass-MacBook-Pro contract-cli % ./contract-cli download-certificate --version 1.0.25 --out encryption-cert
Successfully stored certificates
vikassharma@Vikass-MacBook-Pro contract-cli % ./contract-cli get-certificate --in encryption-cert --version 1.0.25 --out extracted-encryption-cert
Successfully added encryption certificate 
vikassharma@Vikass-MacBook-Pro contract-cli % ./contract-cli encrypt --in samples/contract.yaml --cert extracted-encryption-cert --out encrypted-contract
Successfully generated signed and encrypted contract
```

## Checklist
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass
