### PR TITLE
fix: Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,6 @@ on:
         default: 'true'
         required: false
 
-permissions:
-  contents: read
-
 env:
   # Currently no way to detect automatically
   DEFAULT_BRANCH: main
@@ -27,6 +24,8 @@ jobs:
   commit-lint:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:
@@ -71,6 +70,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       # full checkout for semantic-release
       - uses: actions/checkout@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,9 @@ on:
         default: 'true'
         required: false
 
+permissions:
+  contents: read
+
 env:
   # Currently no way to detect automatically
   DEFAULT_BRANCH: main


### PR DESCRIPTION
Potential fix for [https://github.com/ibm-hyper-protect/contract-go/security/code-scanning/1](https://github.com/ibm-hyper-protect/contract-go/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so all jobs inherit minimal token scopes by default.  
Best single fix (without changing functionality): insert:

```yml
permissions:
  contents: read
```

directly under the workflow triggers (`on:` block) and before `env:`. This satisfies CodeQL’s requirement and enforces least privilege for jobs that only need repository read access.  
File to change: `.github/workflows/build.yml` in the top-level section between `on:` and `env:`.  
No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
