### PR TITLE
feat: Support Sealed Secret Creation in Contract-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ Learn more:
   - Validate network-config schemas for on-premise deployments
   - Support CCRT, CCRV, and CCCO configurations
 
+- **Sealed Secret Management**
+  - Create sealed secrets for workload and environment configurations
+  - Automatic RSA key pair generation for encryption and signing
+  - AES-256-GCM encryption with RSA key wrapping
+  - RSA-SHA512 digital signatures for integrity
+  - JWS (JSON Web Signature) compact serialization format
+  - Compatible with Go crypto packages for decryption
+
 ## Installation
 
 ```bash
@@ -394,6 +402,59 @@ func main() {
     }
 
     fmt.Printf("%s\n", msg)
+}
+```
+
+### Seal Secrets
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/ibm-hyper-protect/contract-go/v2/secrets"
+)
+
+func main() {
+    // Example 1: Seal a workload secret with auto-generated keys
+    sealedSecret, decryptionKey, verificationKey, inputHash, encryptedHash, err := secrets.HpccSealedSecret(
+        "my-database-password",
+        "workload",
+        "",  // Auto-generate encryption key
+        "",  // Auto-generate signing key
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Println("Sealed Secret:", sealedSecret)
+    fmt.Println("Decryption Key:", decryptionKey)
+    fmt.Println("Verification Key:", verificationKey)
+    fmt.Println("Input SHA256:", inputHash)
+    fmt.Println("Encrypted SHA256:", encryptedHash)
+
+    // Example 2: Seal a secret with provided key strings (PEM format)
+    encryptionKeyPEM := `-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA...
+-----END RSA PRIVATE KEY-----`
+
+    signingKeyPEM := `-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA...
+-----END RSA PRIVATE KEY-----`
+
+    sealedSecret2, _, _, _, _, err := secrets.HpccSealedSecret(
+        "my-api-key",
+        "env",
+        encryptionKeyPEM,  // Provide encryption key as PEM string
+        signingKeyPEM,     // Provide signing key as PEM string
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Println("Sealed Secret with Custom Keys:", sealedSecret2)
 }
 ```
 

--- a/common/secrets/secret.go
+++ b/common/secrets/secret.go
@@ -1,0 +1,317 @@
+// Copyright (c) 2026 IBM Corp.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secrets
+
+import (
+	"crypto"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha512"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+)
+
+// EncryptSecretNative encrypts a secret using native Go cryptography without external dependencies.
+//
+// This function performs the complete sealed secret encryption workflow using only Go's standard
+// crypto packages:
+//  1. Generates random AES-256 key and IV
+//  2. Encrypts the secret with AES-256-GCM
+//  3. Encrypts the AES key with RSA-PKCS1v15
+//  4. Creates a JSON envelope with encrypted data and key
+//  5. Signs the envelope with RSA-SHA512
+//  6. Constructs JWS compact serialization format
+//
+// The output format is "sealed.<header>.<payload>.<signature>" compatible with IBM Confidential
+// Computing contract decryption mechanisms.
+//
+// Parameters:
+//   - secret: The plaintext secret to encrypt
+//   - publicKeyPEM: RSA public key for encrypting the AES key (PEM format)
+//   - privateKeyPEM: RSA private key for signing the envelope (PEM format)
+//   - secretType: Type of secret ("workload" or "env") - determines key IDs in the envelope
+//
+// Returns:
+//   - Sealed secret in JWS format with "sealed." prefix
+//   - Error if any encryption step fails
+func EncryptSecretNative(secret string, publicKeyPEM, privateKeyPEM []byte, secretType string) (string, error) {
+	aesKey := make([]byte, 32)
+	if _, err := rand.Read(aesKey); err != nil {
+		return "", fmt.Errorf("failed to generate AES key: %w", err)
+	}
+
+	iv := make([]byte, 12)
+	if _, err := rand.Read(iv); err != nil {
+		return "", fmt.Errorf("failed to generate IV: %w", err)
+	}
+
+	encryptedData, err := encryptWithAESGCMNative([]byte(secret), aesKey, iv)
+	if err != nil {
+		return "", fmt.Errorf("AES-GCM encryption failed: %w", err)
+	}
+
+	pubKey, err := parseRSAPublicKeyFromPEM(publicKeyPEM)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse public key: %w", err)
+	}
+
+	encryptedKey, err := rsa.EncryptPKCS1v15(rand.Reader, pubKey, aesKey)
+	if err != nil {
+		return "", fmt.Errorf("RSA encryption of AES key failed: %w", err)
+	}
+
+	var keyID, verifyKeyID string
+	if secretType == "workload" {
+		keyID = "workload_decrypt"
+		verifyKeyID = "workload_verify"
+	} else {
+		keyID = "env_decrypt"
+		verifyKeyID = "env_verify"
+	}
+
+	envelopeJSON, err := createEnvelopeNative(encryptedData, encryptedKey, iv, keyID)
+	if err != nil {
+		return "", fmt.Errorf("envelope creation failed: %w", err)
+	}
+
+	privKey, err := parseRSAPrivateKeyFromPEM(privateKeyPEM)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse private key: %w", err)
+	}
+
+	sealedSecret, err := constructJWSNative(envelopeJSON, privKey, verifyKeyID)
+	if err != nil {
+		return "", fmt.Errorf("JWS construction failed: %w", err)
+	}
+
+	return sealedSecret, nil
+}
+
+// encryptWithAESGCMNative encrypts data using AES-256-GCM.
+//
+// Parameters:
+//   - plaintext: Data to encrypt
+//   - key: AES-256 key (32 bytes)
+//   - iv: Initialization vector (12 bytes for GCM)
+//
+// Returns:
+//   - Encrypted ciphertext with authentication tag
+//   - Error if cipher creation or encryption fails
+func encryptWithAESGCMNative(plaintext, key, iv []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AES cipher: %w", err)
+	}
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM: %w", err)
+	}
+
+	ciphertext := aesgcm.Seal(nil, iv, plaintext, nil)
+	return ciphertext, nil
+}
+
+// parseRSAPublicKeyFromPEM parses an RSA public key from PEM format.
+//
+// Parameters:
+//   - pemBytes: PEM-encoded RSA public key
+//
+// Returns:
+//   - Parsed RSA public key
+//   - Error if PEM decoding or parsing fails
+func parseRSAPublicKeyFromPEM(pemBytes []byte) (*rsa.PublicKey, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM block")
+	}
+
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse public key: %w", err)
+	}
+
+	rsaPub, ok := pub.(*rsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("not an RSA public key")
+	}
+
+	return rsaPub, nil
+}
+
+// parseRSAPrivateKeyFromPEM parses an RSA private key from PEM format.
+//
+// This function supports both PKCS1 and PKCS8 formats, trying PKCS1 first then falling back to PKCS8.
+//
+// Parameters:
+//   - pemBytes: PEM-encoded RSA private key
+//
+// Returns:
+//   - Parsed RSA private key
+//   - Error if PEM decoding or parsing fails for both formats
+func parseRSAPrivateKeyFromPEM(pemBytes []byte) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM block")
+	}
+
+	privKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err == nil {
+		return privKey, nil
+	}
+
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse private key: %w", err)
+	}
+
+	rsaPriv, ok := key.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("not an RSA private key")
+	}
+
+	return rsaPriv, nil
+}
+
+// createEnvelopeNative creates the JSON envelope structure for the sealed secret.
+//
+// Parameters:
+//   - encryptedData: AES-GCM encrypted secret data
+//   - encryptedKey: RSA-encrypted AES key
+//   - iv: Initialization vector used for AES-GCM
+//   - keyID: Key identifier ("workload_decrypt" or "env_decrypt")
+//
+// Returns:
+//   - JSON-encoded envelope
+//   - Error if JSON marshaling fails
+func createEnvelopeNative(encryptedData, encryptedKey, iv []byte, keyID string) ([]byte, error) {
+	env := map[string]interface{}{
+		"version":        "0.1.0",
+		"type":           "kms",
+		"key_id":         keyID,
+		"encrypted_key":  base64.StdEncoding.EncodeToString(encryptedKey),
+		"encrypted_data": base64.StdEncoding.EncodeToString(encryptedData),
+		"wrap_type":      "A256GCM",
+		"iv":             base64.StdEncoding.EncodeToString(iv),
+		"provider":       "ibm-hpcr-contract",
+	}
+
+	return json.Marshal(env)
+}
+
+// constructJWSNative constructs JWS compact serialization format with RS512 signing.
+//
+// This follows the JWS specification (RFC 7515) where the signature is computed over:
+// ASCII(BASE64URL(UTF8(JWS Protected Header)) || '.' || BASE64URL(JWS Payload))
+//
+// Parameters:
+//   - envelopeJSON: JSON envelope containing encrypted data and key
+//   - privKey: RSA private key for signing
+//   - verifyKeyID: Key identifier for verification ("workload_verify" or "env_verify")
+//
+// Returns:
+//   - Sealed secret in format "sealed.<header>.<payload>.<signature>"
+//   - Error if signing or encoding fails
+func constructJWSNative(envelopeJSON []byte, privKey *rsa.PrivateKey, verifyKeyID string) (string, error) {
+	header := map[string]interface{}{
+		"alg": "RS512",
+		"kid": verifyKeyID,
+	}
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal JWS header: %w", err)
+	}
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerJSON)
+
+	payloadB64 := base64.RawURLEncoding.EncodeToString(envelopeJSON)
+
+	signingInput := headerB64 + "." + payloadB64
+
+	hashed := sha512.Sum512([]byte(signingInput))
+
+	signature, err := rsa.SignPKCS1v15(rand.Reader, privKey, crypto.SHA512, hashed[:])
+	if err != nil {
+		return "", fmt.Errorf("signing failed: %w", err)
+	}
+
+	signatureB64 := base64.RawURLEncoding.EncodeToString(signature)
+
+	jws := fmt.Sprintf("%s.%s.%s", headerB64, payloadB64, signatureB64)
+
+	return "sealed." + jws, nil
+}
+
+// ExtractPublicKeyFromPrivateNative extracts the RSA public key from a private key.
+//
+// Parameters:
+//   - privateKeyPEM: RSA private key in PEM format
+//
+// Returns:
+//   - RSA public key in PEM format
+//   - Error if private key parsing or public key extraction fails
+func ExtractPublicKeyFromPrivateNative(privateKeyPEM []byte) ([]byte, error) {
+	privKey, err := parseRSAPrivateKeyFromPEM(privateKeyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse private key: %w", err)
+	}
+
+	pubKeyBytes, err := x509.MarshalPKIXPublicKey(&privKey.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal public key: %w", err)
+	}
+
+	publicKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: pubKeyBytes,
+	})
+
+	return publicKeyPEM, nil
+}
+
+// GenerateRSAKeyPairNative generates a 2048-bit RSA key pair.
+//
+// Returns:
+//   - RSA public key in PEM format
+//   - RSA private key in PEM format (PKCS1)
+//   - Error if key generation or encoding fails
+func GenerateRSAKeyPairNative() (publicKeyPEM, privateKeyPEM []byte, err error) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate RSA key: %w", err)
+	}
+
+	privKeyBytes := x509.MarshalPKCS1PrivateKey(privKey)
+	privateKeyPEM = pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: privKeyBytes,
+	})
+
+	pubKeyBytes, err := x509.MarshalPKIXPublicKey(&privKey.PublicKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal public key: %w", err)
+	}
+	publicKeyPEM = pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: pubKeyBytes,
+	})
+
+	return publicKeyPEM, privateKeyPEM, nil
+}

--- a/common/secrets/secret_test.go
+++ b/common/secrets/secret_test.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 IBM Corp.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secrets
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateRSAKeyPairNative(t *testing.T) {
+	pubKey, privKey, err := GenerateRSAKeyPairNative()
+	assert.NoError(t, err, "Failed to generate RSA key pair")
+
+	assert.NotEmpty(t, pubKey, "Public key is empty")
+	assert.NotEmpty(t, privKey, "Private key is empty")
+
+	// Check PEM format
+	assert.Contains(t, string(pubKey), "BEGIN PUBLIC KEY", "Public key not in PEM format")
+	assert.Contains(t, string(privKey), "BEGIN RSA PRIVATE KEY", "Private key not in PEM format")
+}
+
+func TestEncryptSecretNative(t *testing.T) {
+	// Generate keys
+	encPubKey, _, err := GenerateRSAKeyPairNative()
+	assert.NoError(t, err, "Failed to generate encryption keys")
+
+	_, signPrivKey, err := GenerateRSAKeyPairNative()
+	assert.NoError(t, err, "Failed to generate signing keys")
+
+	// Encrypt a secret
+	secret := "test-secret-password"
+	sealed, err := EncryptSecretNative(secret, encPubKey, signPrivKey, "workload")
+	assert.NoError(t, err, "Failed to encrypt secret")
+
+	// Verify format
+	assert.True(t, strings.HasPrefix(sealed, "sealed."), "Sealed secret doesn't have 'sealed.' prefix")
+
+	// Verify JWS structure (sealed.header.payload.signature)
+	parts := strings.Split(sealed, ".")
+	assert.Equal(t, 4, len(parts), "Expected 4 parts in sealed secret")
+}
+
+func TestEncryptWithProvidedKeysNative(t *testing.T) {
+	// Your provided keys
+	decryptionKey := []byte(`-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC06q3Joxn75PEw
+T1fSHr2mouEcXS/3tn0R6obh5nqMEKb5j+a6H9hqQmPogKGWupZbWDFv9/6EFqez
+rgtWDeRa4l9gNBt5ykypUBZjjeZNG8oMp7VliOexXyqrIV+3xYypZzHSs3zegv72
+LKtAmuzCmAPYMRrGRXcb4ivPRErGFsgXiVGSpswAjnoitofsXWtKP8LJWPsP9Ooq
+2zQfOLKjm1h3Yq9+FR8liscSwc9o2TdGNKg2Q7K6lkKJR4UEPKJ9RADU8zfs09KA
+/vr1XvOGJ52xWgzEjJgb89ZJIiH0ww8x0laTqd4pY4gR4yaI0Itd2MOfClsyBFal
+rQ9m5J65AgMBAAECggEAAjnF4A5p3iuznObI+4yFxERKNS1fTvKXiM4kESji9pCo
+4TaYPc9w++Ors3tLoZ1ThrWnzAsWvjzCHOeF+63JkqWoyzfw45dtyIJz+A8Rl37B
+RlUU2fYsdYXocjkDorDjOV1L413yahFd/hzQEYgmZAF3QKRgAjLuE3F9nPvn2JZ/
+XIcrEtw5f8HVbUxIP79c4x/9Cm+/ZcnC6EtZMvOGAeO3tuSL1ZQ/rO/K+t+hqVvF
+n4VjPfZC9Js2QuiTppZ3MjQ/E2BdSYTtheh2QTnl0nblxvttdX6s0id+oBFHrtHp
+6J0PGSP/z0MTiEi1llc7oQb3hZzwCg3R8jQgzNPUYQKBgQDf/wlm3I2nZa61Tti3
+j7+QVO3cbaWcnStU7O85oWukVT7IyLeogQiSMq8cSNyUu7NjlPbl6M+GKYHcnegK
+3jC4lpehdUzJSdg49VlYRBUtqxLfyZlyhyILVsGFn0wo1HlooWelTL1Q/NkQNi/m
+x2vK2PP5s3YUME881Y3zAvKasQKBgQDOw/Nh2fZrVpTGnI06e7KwfnLKM8KpnBgH
+Dg3L4TF8CWNvLk63QFY2rutAhovByLazc1JQcLKDc0JSWo5fL8X4IrPneJgr1fSu
+KDBW+9tXFdTsTSJ/HdwfHxzz2UF0DcLzKDOJIHkmIqeWJXJbcW+OqlSeja+JIfr0
+fzW7o/a2iQKBgQCc8BZJQEvrNf3jQBvs+EUyPZ7t6tC22xOKC/tMOIGvgJ5dlOvA
+nq8/p00zFwWdG6mDItKdoLENgbVfui7itmwSWEhiskmbWiapOZVgl0rzVUIDEz90
+k6NRqHYsRcDZdoydt0Bj+1FFFfKLPjvviFdIpxrBH3Ciknph2An9clpB8QKBgGvZ
+ObHohugmGSQftGq06te0nRtrNDZT/RRw+DFIHQ+dtgfgF57uKAoN4xedFnjVwLaJ
+iH38yqBWFlnuciSkPpbXQw+Rj44N47qTq+MzK42ZDZ7T/RJg+Ngi2m82+zUVmIJM
+jdUQ4yBJIzDmB2g7Gv1HSywIq27UEppFYDmnpKBBAoGBANimfhp4T7aUtpQCG1cT
+0HshnjfMXY70o1yi9oOI9c3UChIE0wN+AVXh5jPvb2LjSgc463aGmqMYl1CKhBvT
+ECOyx/rCAYJjNK7FShli71VB9Kpd/1QW9Lk4nLrEhIh+9Hd3qlboxEHLOyfnYdmm
+xtFuPG58m22czKDvYDqLuM4I
+-----END PRIVATE KEY-----`)
+
+	// Generate encryption public key
+	encPubKey, _, err := GenerateRSAKeyPairNative()
+	assert.NoError(t, err, "Failed to generate keys")
+
+	// Encrypt with provided keys
+	secret := "test-password"
+	sealed, err := EncryptSecretNative(secret, encPubKey, decryptionKey, "workload")
+	assert.NoError(t, err, "Failed to encrypt with provided keys")
+
+	// Verify format
+	assert.True(t, strings.HasPrefix(sealed, "sealed."), "Sealed secret doesn't have 'sealed.' prefix")
+
+	// Verify JWS structure
+	parts := strings.Split(sealed, ".")
+	assert.Equal(t, 4, len(parts), "Expected 4 parts in sealed secret")
+}
+
+// TestExtractPublicKeyFromPrivateNative tests extracting public key from private key
+func TestExtractPublicKeyFromPrivateNative(t *testing.T) {
+	// Generate a key pair
+	pubKey, privKey, err := GenerateRSAKeyPairNative()
+	assert.NoError(t, err, "Failed to generate key pair")
+
+	// Extract public key from private key
+	extractedPubKey, err := ExtractPublicKeyFromPrivateNative(privKey)
+	assert.NoError(t, err, "Failed to extract public key")
+
+	// Verify the extracted public key matches the original
+	assert.Equal(t, string(pubKey), string(extractedPubKey), "Extracted public key doesn't match original public key")
+
+	// Verify the extracted key is valid PEM
+	block, _ := pem.Decode(extractedPubKey)
+	assert.NotNil(t, block, "Failed to decode extracted public key PEM")
+	assert.Equal(t, "PUBLIC KEY", block.Type, "Expected PUBLIC KEY block type")
+
+	// Verify we can parse it as a public key
+	_, err = x509.ParsePKIXPublicKey(block.Bytes)
+	assert.NoError(t, err, "Failed to parse extracted public key")
+}
+
+// TestExtractPublicKeyFromPrivateNative_InvalidKey tests error handling
+func TestExtractPublicKeyFromPrivateNative_InvalidKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		privKey []byte
+		wantErr bool
+	}{
+		{
+			name:    "empty key",
+			privKey: []byte{},
+			wantErr: true,
+		},
+		{
+			name:    "invalid PEM",
+			privKey: []byte("not a valid PEM"),
+			wantErr: true,
+		},
+		{
+			name: "invalid key data",
+			privKey: []byte(`-----BEGIN RSA PRIVATE KEY-----
+invalid data here
+-----END RSA PRIVATE KEY-----`),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ExtractPublicKeyFromPrivateNative(tt.privKey)
+			if tt.wantErr {
+				assert.Error(t, err, "ExtractPublicKeyFromPrivateNative() should return error")
+			} else {
+				assert.NoError(t, err, "ExtractPublicKeyFromPrivateNative() should not return error")
+			}
+		})
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ The encryption process:
 - [Attestation Functions](#attestation-functions)
 - [Certificate Functions](#certificate-functions)
 - [Contract Functions](#contract-functions)
+- [Sealed Secret Functions](#sealed-secret-functions)
 - [Image Functions](#image-functions)
 - [Network Functions](#network-functions)
 - [Common Patterns](#common-patterns)
@@ -2045,6 +2046,269 @@ func main() {
 - `"failed while parsing the template toml"` - Error while parsing the template initdata toml file
 - `"failed while creating initdata.toml"` - Failed while replacing encrypted contract in initdata.toml file
 - `"failed while gzipping initdata"` - Failed while compressing the content of inidata.toml file
+
+
+---
+
+## Sealed Secret Functions
+
+### HpccSealedSecret
+
+Encrypts a secret using AES-256-GCM with RSA key wrapping and RSA-SHA512 signing for CCCO workload or environment configurations.
+
+**Package:** `github.com/ibm-hyper-protect/contract-go/v2/secrets`
+
+**Signature:**
+```go
+func HpccSealedSecret(secret, secretType, encryptionKey, signingKey string) (string, string, string, string, string, error)
+```
+
+**Parameters:**
+
+| Parameter | Type | Required/Optional | Description |
+|-----------|------|-------------------|-------------|
+| `secret` | `string` | Required | The plaintext secret to encrypt |
+| `secretType` | `string` | Required | Either `"workload"` or `"env"` - determines key IDs used in the sealed secret |
+| `encryptionKey` | `string` | Optional | RSA private key for encryption in PEM format string. If empty string `""`, generates new 2048-bit RSA key |
+| `signingKey` | `string` | Optional | RSA private key for signing in PEM format string. If empty string `""`, generates new 2048-bit RSA key |
+
+**Secret Types:**
+
+| Value | Key IDs Used |
+|-------|--------------|
+| `"workload"` | `workload_decrypt`, `workload_verify` |
+| `"env"` | `env_decrypt`, `env_verify` |
+
+**Returns:**
+
+| Return | Type | Description |
+|--------|------|-------------|
+| `Sealed Secret` | `string` | The encrypted secret in JWS compact serialization format (sealed.\<header\>.\<payload\>.\<signature\>) |
+| `Decryption Private Key` | `string` | RSA private key for decryption in PEM format. **IMPORTANT:** Store securely - needed to decrypt the secret |
+| `Verification Public Key` | `string` | RSA public key for signature verification in PEM format |
+| `Input Checksum` | `string` | SHA-256 hash of the input plaintext secret |
+| `Output Checksum` | `string` | SHA-256 hash of the sealed secret output |
+| `Error` | `error` | Error if encryption fails or inputs are invalid |
+
+**Example 1: Generate New Keys (Recommended for New Secrets):**
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+    "os"
+
+    "github.com/ibm-hyper-protect/contract-go/v2/secrets"
+)
+
+func main() {
+    // Secret to encrypt
+    secret := "my-database-password"
+
+    // Seal the secret - generates new keys automatically
+    sealedSecret, decryptionKey, verificationKey, inputHash, encryptedHash, err := secrets.HpccSealedSecret(
+        secret,
+        "workload",
+        "",  // Empty string to auto-generate encryption key
+        "",  // Empty string to auto-generate signing key
+    )
+    if err != nil {
+        log.Fatalf("Failed to seal secret: %v", err)
+    }
+
+    fmt.Printf("Sealed Secret:\n%s\n\n", sealedSecret)
+    fmt.Printf("Input SHA256: %s\n", inputHash)
+    fmt.Printf("Output SHA256: %s\n\n", encryptedHash)
+    
+    // IMPORTANT: Save the decryption key securely
+    err = os.WriteFile("decryption-key.pem", []byte(decryptionKey), 0600)
+    if err != nil {
+        log.Fatalf("Failed to save decryption key: %v", err)
+    }
+    
+    // Save verification key (can be shared publicly)
+    err = os.WriteFile("verification-key.pem", []byte(verificationKey), 0644)
+    if err != nil {
+        log.Fatalf("Failed to save verification key: %v", err)
+    }
+
+    fmt.Println("Keys saved successfully!")
+    fmt.Println("Use the sealed secret in your contract")
+}
+```
+
+**Example 2: Use Existing Key Strings (PEM Format):**
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/ibm-hyper-protect/contract-go/v2/secrets"
+)
+
+func main() {
+    // Provide keys as PEM format strings
+    encryptionKeyPEM := `-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN
+... (your encryption key content) ...
+-----END RSA PRIVATE KEY-----`
+
+    signingKeyPEM := `-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAabcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMN
+... (your signing key content) ...
+-----END RSA PRIVATE KEY-----`
+
+    // Seal secret with provided key strings
+    secret := "my-api-token"
+    sealedSecret, _, _, inputHash, encryptedHash, err := secrets.HpccSealedSecret(
+        secret,
+        "env",
+        encryptionKeyPEM,  // Provide encryption key as PEM string
+        signingKeyPEM,     // Provide signing key as PEM string
+    )
+    if err != nil {
+        log.Fatalf("Failed to seal secret: %v", err)
+    }
+
+    fmt.Printf("Sealed Secret:\n%s\n", sealedSecret)
+    fmt.Printf("Input SHA256: %s\n", inputHash)
+    fmt.Printf("Output SHA256: %s\n", encryptedHash)
+}
+```
+
+**Example 3: Seal Multiple Secrets with Same Keys:**
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/ibm-hyper-protect/contract-go/v2/secrets"
+)
+
+func main() {
+    // Generate keys once
+    firstSealed, decryptKey, signKey, _, _, err := secrets.HpccSealedSecret(
+        "first-secret",
+        "workload",
+        "",  // Auto-generate
+        "",  // Auto-generate
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Reuse the same keys (as strings) for additional secrets
+    secondSealed, _, _, _, _, err := secrets.HpccSealedSecret(
+        "second-secret",
+        "workload",
+        decryptKey,  // Reuse encryption key string
+        signKey,     // Reuse signing key string (can use same key for both)
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Printf("First Sealed Secret:\n%s\n\n", firstSealed)
+    fmt.Printf("Second Sealed Secret:\n%s\n", secondSealed)
+}
+```
+
+**Example 4: Using Sealed Secrets in Contracts:**
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/ibm-hyper-protect/contract-go/v2/secrets"
+)
+
+func main() {
+    // Seal database password for workload
+    dbPassword := "super-secret-db-password"
+    workloadSealed, _, _, _, _, err := secrets.HpccSealedSecret(
+        dbPassword,
+        "workload",
+        "",
+        "",
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Seal API key for environment
+    apiKey := "my-api-key-12345"
+    envSealed, _, _, _, _, err := secrets.HpccSealedSecret(
+        apiKey,
+        "env",
+        "",
+        "",
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Printf("Workload Sealed Secret:\n%s\n\n", workloadSealed)
+    fmt.Printf("Environment Sealed Secret:\n%s\n", envSealed)
+}
+```
+
+**Sealed Secret Format:**
+
+The sealed secret uses JWS (JSON Web Signature) compact serialization format:
+
+```
+sealed.<header>.<payload>.<signature>
+```
+
+Where:
+- **Header**: Base64URL-encoded JSON containing algorithm (`RS512`) and key ID
+- **Payload**: Base64URL-encoded JSON envelope with encrypted data and metadata
+- **Signature**: Base64URL-encoded RSA-SHA512 signature
+
+**Encryption Process:**
+
+1. Generate random 32-byte AES-256 key
+2. Generate random 12-byte initialization vector (IV)
+3. Encrypt secret with AES-256-GCM using key and IV
+4. Encrypt AES key with RSA-PKCS1v15 using public key
+5. Create JSON envelope with encrypted data and key
+6. Sign envelope with RSA-SHA512 using private key
+7. Construct JWS format with header, payload, and signature
+
+**Security Features:**
+
+- **AES-256-GCM**: Authenticated encryption with associated data (AEAD)
+- **RSA Key Wrapping**: Secure key exchange using RSA-PKCS1v15
+- **RSA-SHA512 Signing**: Strong signature algorithm for integrity verification
+- **JWS Format**: Industry-standard format for signed data
+
+**Use Cases:**
+
+- Enables sealing of k8s/OCP secrets
+- Supports secrets both in Env and Workload section of CCCO contract
+
+
+**Common Errors:**
+
+- `"secret cannot be empty"` - Secret parameter is empty
+- `"invalid secret type: must be 'workload' or 'env'"` - Invalid secretType value (must be lowercase string)
+- `"failed to extract public key from encryption private key"` - Invalid encryption key PEM format
+- `"failed to extract public key from signing private key"` - Invalid signing key PEM format
+- `"failed to generate encryption key pair"` - Key generation failed
+- `"failed to generate signing key pair"` - Key generation failed
+- `"failed to encrypt secret"` - Encryption operation failed
+
 
 
 ### HpcrVerifyNetworkConfig

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
-github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/secrets/secret.go
+++ b/secrets/secret.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 IBM Corp.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secrets
+
+import (
+	"fmt"
+
+	"github.com/ibm-hyper-protect/contract-go/v2/common/general"
+	csecrets "github.com/ibm-hyper-protect/contract-go/v2/common/secrets"
+)
+
+// HpccSealedSecret encrypts a secret using AES-256-GCM with RSA key wrapping and RSA-SHA512 signing.
+//
+// Use this function to create sealed secrets for IBM Confidential Computing workload or environment
+// configurations. The function performs the complete encryption workflow: generates or uses provided
+// RSA key pairs (as PEM strings or generates new ones), encrypts the secret with AES-256-GCM,
+// wraps the AES key with RSA, and signs the result with RSA-SHA512. The output is in JWS compact
+// serialization format compatible with IBM Confidential Computing contracts.
+//
+// Parameters:
+//   - secret: The plaintext secret to encrypt (must not be empty)
+//   - secretType: Either "workload" or "env", determines key IDs used in the sealed secret
+//   - encryptionKey: Optional RSA private key in PEM format string for encryption. If empty, generates new key.
+//   - signingKey: Optional RSA private key in PEM format string for signing. If empty, generates new key.
+//
+// Returns:
+//   - sealedSecret: The encrypted secret in JWS format (sealed.<header>.<payload>.<signature>)
+//   - decryptionKey: RSA private key for decryption (PEM format string) - store securely
+//   - verificationKey: RSA public key for signature verification (PEM format string)
+//   - inputSecretSha: SHA-256 hash of the input plaintext secret
+//   - encryptedSecretSha: SHA-256 hash of the sealed secret (output)
+//   - Error if encryption fails, keys cannot be parsed/generated, or inputs are invalid
+func HpccSealedSecret(secret, secretType, encryptionKey, signingKey string) (string, string, string, string, string, error) {
+	var err error
+	if secret == "" {
+		return "", "", "", "", "", fmt.Errorf("secret cannot be empty")
+	}
+
+	if secretType != "workload" && secretType != "env" {
+		return "", "", "", "", "", fmt.Errorf("invalid secret type: must be 'workload' or 'env'")
+	}
+
+	var encPubKey, encPrivKey, signPubKey, signPrivKey []byte
+
+	// Handle encryption key - use provided string or generate new
+	if encryptionKey != "" {
+		encPrivKey = []byte(encryptionKey)
+		encPubKey, err = csecrets.ExtractPublicKeyFromPrivateNative(encPrivKey)
+		if err != nil {
+			return "", "", "", "", "", fmt.Errorf("failed to extract public key from encryption private key: %w", err)
+		}
+	} else {
+		encPubKey, encPrivKey, err = csecrets.GenerateRSAKeyPairNative()
+		if err != nil {
+			return "", "", "", "", "", fmt.Errorf("failed to generate encryption key pair: %w", err)
+		}
+	}
+
+	// Handle signing key - use provided string or generate new
+	if signingKey != "" {
+		signPrivKey = []byte(signingKey)
+		signPubKey, err = csecrets.ExtractPublicKeyFromPrivateNative(signPrivKey)
+		if err != nil {
+			return "", "", "", "", "", fmt.Errorf("failed to extract public key from signing private key: %w", err)
+		}
+	} else {
+		signPubKey, signPrivKey, err = csecrets.GenerateRSAKeyPairNative()
+		if err != nil {
+			return "", "", "", "", "", fmt.Errorf("failed to generate signing key pair: %w", err)
+		}
+	}
+
+	// Encrypt the secret
+	sealed, err := csecrets.EncryptSecretNative(secret, encPubKey, signPrivKey, secretType)
+	if err != nil {
+		return "", "", "", "", "", fmt.Errorf("failed to encrypt secret: %w", err)
+	}
+
+	// Generate SHA-256 hashes
+	inputSha := general.GenerateSha256(secret)
+	encryptedSha := general.GenerateSha256(sealed)
+
+	return sealed, string(encPrivKey), string(signPubKey), inputSha, encryptedSha, nil
+}

--- a/secrets/secret_test.go
+++ b/secrets/secret_test.go
@@ -1,0 +1,353 @@
+// Copyright (c) 2026 IBM Corp.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secrets
+
+import (
+	"crypto"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha512"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/ibm-hyper-protect/contract-go/v2/common/general"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestHpccSealedSecretWorkload tests sealing a workload secret.
+func TestHpccSealedSecretWorkload(t *testing.T) {
+	sealedSecret, decryptionKey, verificationKey, inputSha, encryptedSha, err := HpccSealedSecret("test-secret", "workload", "", "")
+	assert.NoError(t, err, "Failed to seal secret")
+
+	// Verify sealed secret format
+	assert.True(t, strings.HasPrefix(sealedSecret, "sealed."), "Sealed secret doesn't have 'sealed.' prefix")
+
+	// Verify sealed secret has JWS structure (sealed.header.payload.signature)
+	parts := strings.Split(sealedSecret, ".")
+	assert.Equal(t, 4, len(parts), "Expected 4 parts in sealed secret (sealed.header.payload.signature)")
+
+	// Verify all keys are present
+	assert.NotEmpty(t, decryptionKey, "Decryption key is empty")
+	assert.NotEmpty(t, verificationKey, "Verification key is empty")
+
+	// Verify keys are in PEM format
+	assert.Contains(t, decryptionKey, "BEGIN", "Decryption key not in PEM format")
+	assert.Contains(t, verificationKey, "BEGIN PUBLIC KEY", "Verification key not in PEM format")
+
+	// Verify SHA hashes are present
+	assert.NotEmpty(t, inputSha, "Input SHA is empty")
+	assert.NotEmpty(t, encryptedSha, "Encrypted SHA is empty")
+	assert.Equal(t, 64, len(inputSha), "Input SHA should be 64 characters (SHA-256 hex)")
+	assert.Equal(t, 64, len(encryptedSha), "Encrypted SHA should be 64 characters (SHA-256 hex)")
+}
+
+// TestHpccSealedSecretEnv tests sealing an environment secret.
+func TestHpccSealedSecretEnv(t *testing.T) {
+	sealedSecret, _, _, _, _, err := HpccSealedSecret("test-secret", "env", "", "")
+	assert.NoError(t, err, "Failed to seal secret")
+
+	assert.True(t, strings.HasPrefix(sealedSecret, "sealed."), "Sealed secret doesn't have 'sealed.' prefix")
+
+	// Verify JWS structure
+	parts := strings.Split(sealedSecret, ".")
+	assert.Equal(t, 4, len(parts), "Expected 4 parts in sealed secret")
+}
+
+// TestHpccSealedSecretEmptySecret tests that empty secrets are rejected.
+func TestHpccSealedSecretEmptySecret(t *testing.T) {
+	_, _, _, _, _, err := HpccSealedSecret("", "workload", "", "")
+	assert.Error(t, err, "Expected error for empty secret")
+	assert.Contains(t, err.Error(), "empty", "Expected error message to mention 'empty'")
+}
+
+// TestHpccSealedSecretInvalidType tests that invalid secret types are rejected.
+func TestHpccSealedSecretInvalidType(t *testing.T) {
+	_, _, _, _, _, err := HpccSealedSecret("test", "invalid", "", "")
+	assert.Error(t, err, "Expected error for invalid secret type")
+	assert.Contains(t, err.Error(), "invalid secret type", "Expected error message to mention 'invalid secret type'")
+}
+
+// TestHpccSealedSecretDifferentSecrets tests that different secrets produce different results.
+func TestHpccSealedSecretDifferentSecrets(t *testing.T) {
+	sealed1, decKey1, _, inputSha1, encSha1, err := HpccSealedSecret("secret1", "workload", "", "")
+	assert.NoError(t, err, "Failed to seal first secret")
+
+	sealed2, decKey2, _, inputSha2, encSha2, err := HpccSealedSecret("secret2", "workload", "", "")
+	assert.NoError(t, err, "Failed to seal second secret")
+
+	// Sealed secrets should be different
+	assert.NotEqual(t, sealed1, sealed2, "Different secrets produced identical sealed secrets")
+
+	// Keys should be different (freshly generated each time)
+	assert.NotEqual(t, decKey1, decKey2, "Different calls produced identical decryption keys")
+
+	// Input SHAs should be different
+	assert.NotEqual(t, inputSha1, inputSha2, "Different secrets produced identical input SHAs")
+
+	// Encrypted SHAs should be different
+	assert.NotEqual(t, encSha1, encSha2, "Different secrets produced identical encrypted SHAs")
+}
+
+// TestHpccSealedSecretLongSecret tests sealing a longer secret.
+func TestHpccSealedSecretLongSecret(t *testing.T) {
+	longSecret := strings.Repeat("This is a long secret. ", 100)
+	sealedSecret, _, _, _, _, err := HpccSealedSecret(longSecret, "workload", "", "")
+	assert.NoError(t, err, "Failed to seal long secret")
+	assert.True(t, strings.HasPrefix(sealedSecret, "sealed."), "Sealed secret doesn't have 'sealed.' prefix")
+}
+
+// TestHpccSealedSecretSpecialCharacters tests sealing secrets with special characters.
+func TestHpccSealedSecretSpecialCharacters(t *testing.T) {
+	specialSecrets := []string{
+		"password!@#$%^&*()",
+		"key with spaces",
+		"unicode: 你好世界",
+		"newlines\nand\ttabs",
+		`{"json": "value"}`,
+	}
+
+	for _, secret := range specialSecrets {
+		t.Run(secret, func(t *testing.T) {
+			sealedSecret, _, _, _, _, err := HpccSealedSecret(secret, "workload", "", "")
+			assert.NoError(t, err, "Failed to seal secret with special characters")
+			assert.True(t, strings.HasPrefix(sealedSecret, "sealed."), "Sealed secret doesn't have 'sealed.' prefix")
+		})
+	}
+}
+
+// BenchmarkHpccSealedSecret benchmarks the complete seal secret operation.
+func BenchmarkHpccSealedSecret(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _, _, _, _, err := HpccSealedSecret("benchmark-secret", "workload", "", "")
+		assert.NoError(b, err, "Failed to seal secret")
+	}
+}
+
+// TestDecryptWithGoCrypto demonstrates that sealed secrets created with native Go crypto
+// can be decrypted using Go's crypto packages (AES-256-GCM + RSA-OAEP-SHA512).
+func TestDecryptWithGoCrypto(t *testing.T) {
+	originalSecret := "my-test-password-123"
+
+	// Step 1: Create sealed secret using our package
+	sealedSecret, decryptionKeyPEM, _, inputSha, encryptedSha, err := HpccSealedSecret(originalSecret, "workload", "", "")
+	assert.NoError(t, err, "Failed to seal secret")
+
+	// Verify input SHA matches
+	expectedInputSha := general.GenerateSha256(originalSecret)
+	assert.Equal(t, expectedInputSha, inputSha, "Input SHA doesn't match")
+
+	// Verify encrypted SHA matches
+	expectedEncryptedSha := general.GenerateSha256(sealedSecret)
+	assert.Equal(t, expectedEncryptedSha, encryptedSha, "Encrypted SHA doesn't match")
+
+	// Step 2: Parse the JWS format (sealed.header.payload.signature)
+	parts := strings.Split(sealedSecret, ".")
+	assert.Equal(t, 4, len(parts), "Invalid sealed secret format")
+	assert.Equal(t, "sealed", parts[0], "Invalid sealed secret format")
+
+	// Step 3: Decode the payload (envelope)
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[2])
+	assert.NoError(t, err, "Failed to decode payload")
+
+	// Define envelope structure for decryption
+	type envelope struct {
+		Version       string `json:"version"`
+		Type          string `json:"type"`
+		KeyID         string `json:"key_id"`
+		EncryptedKey  string `json:"encrypted_key"`
+		EncryptedData string `json:"encrypted_data"`
+		WrapType      string `json:"wrap_type"`
+		IV            string `json:"iv"`
+		Provider      string `json:"provider"`
+	}
+
+	var env envelope
+	err = json.Unmarshal(payloadBytes, &env)
+	assert.NoError(t, err, "Failed to unmarshal envelope")
+
+	// Verify it's using GCM
+	assert.Equal(t, "A256GCM", env.WrapType, "Expected wrap_type A256GCM")
+
+	// Step 4: Decode the encrypted AES key
+	encryptedAESKey, err := base64.StdEncoding.DecodeString(env.EncryptedKey)
+	assert.NoError(t, err, "Failed to decode encrypted AES key")
+
+	// Step 5: Parse the RSA private key (decryption key)
+	block, _ := pem.Decode([]byte(decryptionKeyPEM))
+	assert.NotNil(t, block, "Failed to parse PEM block")
+
+	privateKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		// Try PKCS1 format
+		privateKey, err = x509.ParsePKCS1PrivateKey(block.Bytes)
+		assert.NoError(t, err, "Failed to parse private key")
+	}
+
+	rsaPrivateKey, ok := privateKey.(*rsa.PrivateKey)
+	assert.True(t, ok, "Not an RSA private key")
+
+	// Step 6: Decrypt the AES key using RSA PKCS#1 v1.5 (same as agent-interceptor)
+	aesKey, err := rsa.DecryptPKCS1v15(rand.Reader, rsaPrivateKey, encryptedAESKey)
+	assert.NoError(t, err, "Failed to decrypt AES key")
+
+	// Step 7: Decode the encrypted data and IV
+	encryptedData, err := base64.StdEncoding.DecodeString(env.EncryptedData)
+	assert.NoError(t, err, "Failed to decode encrypted data")
+
+	iv, err := base64.StdEncoding.DecodeString(env.IV)
+	assert.NoError(t, err, "Failed to decode IV")
+
+	// Step 8: Decrypt the data using AES-256-GCM (Go crypto)
+	block2, err := aes.NewCipher(aesKey)
+	assert.NoError(t, err, "Failed to create AES cipher")
+
+	gcm, err := cipher.NewGCM(block2)
+	assert.NoError(t, err, "Failed to create GCM")
+
+	// GCM decrypt (nonce is the IV, ciphertext includes auth tag)
+	decryptedData, err := gcm.Open(nil, iv, encryptedData, nil)
+	assert.NoError(t, err, "Failed to decrypt data with GCM")
+
+	decryptedSecret := string(decryptedData)
+
+	// Step 9: Verify the decrypted secret matches the original
+	assert.Equal(t, originalSecret, decryptedSecret, "Decrypted secret doesn't match original")
+}
+
+// TestVerifySignatureWithGoCrypto demonstrates signature verification using Go crypto.
+func TestVerifySignatureWithGoCrypto(t *testing.T) {
+	// Step 1: Create sealed secret
+	sealedSecret, _, verificationKeyPEM, _, _, err := HpccSealedSecret("test-secret", "workload", "", "")
+	assert.NoError(t, err, "Failed to seal secret")
+
+	// Step 2: Parse JWS (format: sealed.header.payload.signature)
+	parts := strings.Split(sealedSecret, ".")
+	assert.Equal(t, 4, len(parts), "Invalid JWS format")
+
+	// Step 3: Get the signature
+	signatureBytes, err := base64.RawURLEncoding.DecodeString(parts[3])
+	assert.NoError(t, err, "Failed to decode signature")
+
+	// Step 4: Parse the verification key (RSA public key)
+	block, _ := pem.Decode([]byte(verificationKeyPEM))
+	assert.NotNil(t, block, "Failed to parse PEM block")
+
+	publicKey, err := x509.ParsePKIXPublicKey(block.Bytes)
+	assert.NoError(t, err, "Failed to parse public key")
+
+	rsaPublicKey, ok := publicKey.(*rsa.PublicKey)
+	assert.True(t, ok, "Not an RSA public key")
+
+	// Step 5: Construct the signing input (header.payload)
+	// Per JWS spec, signature is computed over: BASE64URL(header) || '.' || BASE64URL(payload)
+	signingInput := parts[1] + "." + parts[2]
+
+	// Step 6: Verify the signature using Go crypto (RSA-SHA512)
+	hashed := sha512.Sum512([]byte(signingInput))
+	err = rsa.VerifyPKCS1v15(rsaPublicKey, crypto.SHA512, hashed[:], signatureBytes)
+	assert.NoError(t, err, "Signature verification failed")
+}
+
+// TestHpccSealedSecretWithProvidedKeys tests sealing with user-provided encryption and signing keys as strings.
+func TestHpccSealedSecretWithProvidedKeys(t *testing.T) {
+	// Generate keys to use
+	_, encPrivKey, err := generateRSAKeyPairNative()
+	assert.NoError(t, err, "Failed to generate encryption key pair")
+
+	_, signPrivKey, err := generateRSAKeyPairNative()
+	assert.NoError(t, err, "Failed to generate signing key pair")
+
+	// Seal secret with provided key strings
+	sealedSecret, decryptionKey, _, _, _, err := HpccSealedSecret("test-secret", "workload", string(encPrivKey), string(signPrivKey))
+	assert.NoError(t, err, "Failed to seal secret with provided keys")
+
+	// Verify sealed secret format
+	assert.True(t, strings.HasPrefix(sealedSecret, "sealed."), "Sealed secret doesn't have 'sealed.' prefix")
+
+	// Verify the returned keys match what we provided
+	assert.Equal(t, string(encPrivKey), decryptionKey, "Returned decryption key doesn't match provided encryption key")
+
+	// Verify the sealed secret is not empty and has correct format
+	parts := strings.Split(sealedSecret, ".")
+	assert.Equal(t, 4, len(parts), "Expected 4 parts in sealed secret")
+}
+
+// TestHpccSealedSecretWithPartialKeys tests that providing only one key generates the other.
+func TestHpccSealedSecretWithPartialKeys(t *testing.T) {
+	// Generate only encryption key
+	_, encPrivKey, err := generateRSAKeyPairNative()
+	assert.NoError(t, err, "Failed to generate encryption key pair")
+
+	// Seal with only encryption key provided (signing key should be generated)
+	sealed1, decKey1, verKey1, _, _, err := HpccSealedSecret("test-secret", "workload", string(encPrivKey), "")
+	assert.NoError(t, err, "Failed to seal secret with partial keys")
+
+	// Verify sealed secret was created
+	assert.True(t, strings.HasPrefix(sealed1, "sealed."), "Sealed secret doesn't have 'sealed.' prefix")
+
+	// Verify encryption key matches what we provided
+	assert.Equal(t, string(encPrivKey), decKey1, "Returned decryption key doesn't match provided encryption key")
+
+	// Verify signing key was generated (should not be empty)
+	assert.NotEmpty(t, verKey1, "Verification key should have been generated but is empty")
+
+	// Generate only signing key
+	_, signPrivKey, err := generateRSAKeyPairNative()
+	assert.NoError(t, err, "Failed to generate signing key pair")
+
+	// Seal with only signing key provided (encryption key should be generated)
+	sealed2, decKey2, _, _, _, err := HpccSealedSecret("test-secret", "env", "", string(signPrivKey))
+	assert.NoError(t, err, "Failed to seal secret with partial keys")
+
+	// Verify sealed secret was created
+	assert.True(t, strings.HasPrefix(sealed2, "sealed."), "Sealed secret doesn't have 'sealed.' prefix")
+
+	// Verify encryption key was generated (should not be empty)
+	assert.NotEmpty(t, decKey2, "Decryption key should have been generated but is empty")
+}
+
+// Helper function to generate RSA key pair for testing
+func generateRSAKeyPairNative() (publicKeyPEM, privateKeyPEM []byte, err error) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate RSA key: %w", err)
+	}
+
+	privKeyBytes := x509.MarshalPKCS1PrivateKey(privKey)
+	privateKeyPEM = pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: privKeyBytes,
+	})
+
+	pubKeyBytes, err := x509.MarshalPKIXPublicKey(&privKey.PublicKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal public key: %w", err)
+	}
+
+	publicKeyPEM = pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: pubKeyBytes,
+	})
+
+	return publicKeyPEM, privateKeyPEM, nil
+}


### PR DESCRIPTION
Added Sealed Secret Support

## Description

Sealed Secret feature Supports the sealing (Encryption and Signing) of regular k8s/OCP Secret. Sealed secret feature is used in CCCO, Which offers Zero Trust Policy. 

Assisted by - IBM BOB

## Related Issue



Fixes  https://github.com/ibm-hyper-protect/contract-go/issues/226

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactor (no functional changes)
- [ ] CI/CD or build changes

## Target Platform

<!-- Which IBM Confidential Computing platform(s) does this affect? -->

- [ ] HPVS (IBM Hyper Protect Virtual Servers for VPC)
- [ ] CCRT (IBM Confidential Computing Container Runtime)
- [ ] CCRV (IBM Confidential Computing Container Runtime for Red Hat Virtualization Solutions)
- [x] CCCO (IBM Confidential Computing Containers for Red Hat OpenShift Container Platform)
- [ ] All platforms
- [ ] Not platform-specific

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

- [x] `make test` passes
- [x] `make fmt` applied (no formatting changes needed)
- [x] New tests added for new functionality (if applicable)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added/updated GoDoc comments for public functions
- [x] I have updated documentation (README, docs/README.md) if needed
- [x] All new and existing tests pass (`make test`)
- [x] I have verified there are no breaking changes (or documented them above)
