### PR TITLE
fix: version format of hpvs

### DIFF
--- a/encryption/cert.go
+++ b/encryption/cert.go
@@ -115,7 +115,7 @@ func loadCertificatesFromDir(osType string) {
 //   - ibm-hyper-protect-container-runtime-26.2.0-encrypt.crt -> 26.2.0
 //   - ibm-confidential-computing-container-runtime-rhvs-26.4.1-encrypt.crt -> 26.4.1
 //   - ibm-hyper-protect-confidential-container-25.12.0-encrypt.crt -> 25.12.0
-//   - ibm-hyper-protect-container-runtime-1-0-s390x-28-encrypt.crt -> 28
+//   - ibm-hyper-protect-container-runtime-1-0-s390x-28-encrypt.crt -> 1.0.28
 func extractVersionFromFilename(filename string) string {
 	// Pattern to match semantic version (X.Y.Z or X.Y.Z.W)
 	re := regexp.MustCompile(`(\d+\.\d+\.\d+(?:\.\d+)?)-encrypt\.crt$`)
@@ -126,10 +126,11 @@ func extractVersionFromFilename(filename string) string {
 
 	// Pattern to match HPVS format: ibm-hyper-protect-container-runtime-1-0-s390x-XX-encrypt.crt
 	// where XX is the version number
-	reHpvs := regexp.MustCompile(`-s390x-(\d+)-encrypt\.crt$`)
-	matchesHpvs := reHpvs.FindStringSubmatch(filename)
-	if len(matchesHpvs) > 1 {
-		return matchesHpvs[1]
+	reHpvs := regexp.MustCompile(`runtime-(\d+)-(\d+)-s390x-(\d+)-encrypt\.crt$`)
+	matches = reHpvs.FindStringSubmatch(filename)
+	if len(matches) > 1 {
+		version := fmt.Sprintf("%s.%s.%s", matches[1], matches[2], matches[3])
+		return version
 	}
 
 	return ""

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.26.1
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
-github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Description

fix of hpvs encryption cert format.

## Related Issue

<!-- Link the issue this PR addresses. Use "Fixes #123" to auto-close the issue on merge. -->

Fixes https://github.com/ibm-hyper-protect/contract-cli/issues/130

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactor (no functional changes)
- [ ] CI/CD or build changes

## Target Platform

<!-- Which IBM Confidential Computing platform(s) does this affect? -->

- [x] HPVS (IBM Hyper Protect Virtual Servers for VPC)
- [ ] CCRT (IBM Confidential Computing Container Runtime)
- [ ] CCRV (IBM Confidential Computing Container Runtime for Red Hat Virtualization Solutions)
- [ ] CCCO (IBM Confidential Computing Containers for Red Hat OpenShift Container Platform)
- [ ] All platforms
- [ ] Not platform-specific

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

- [x] `make test` passes
- [x] `make fmt` applied (no formatting changes needed)
- [x] New tests added for new functionality (if applicable)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added/updated GoDoc comments for public functions
- [x] I have updated documentation (README, docs/README.md) if needed
- [x] All new and existing tests pass (`make test`)
- [x] I have verified there are no breaking changes (or documented them above)
