### PR TITLE
feat: Added support to verify schema of workload & env separately

### DIFF
--- a/common/general/general.go
+++ b/common/general/general.go
@@ -658,6 +658,7 @@ func GenerateTgzBase64(folderFilesPath []string) (string, error) {
 //   - version: Confidential Computing platform version ("ccrt", "ccrv", "ccco", "hpvs") - defaults to "ccrt" if empty
 //   - section: Section to validate - "" (both), "workload" (only workload), or "env" (only env)
 //
+
 // Returns:
 //   - nil if contract is valid
 //   - Error if contract parsing, schema retrieval, or validation fails

--- a/common/general/general.go
+++ b/common/general/general.go
@@ -655,13 +655,41 @@ func GenerateTgzBase64(folderFilesPath []string) (string, error) {
 //
 // Parameters:
 //   - contract: Contract YAML string to validate
-//   - version: Confidential Computing platform version ("ccrt", "ccrv", "ccco") - defaults to "ccrt" if empty
+//   - version: Confidential Computing platform version ("ccrt", "ccrv", "ccco", "hpvs") - defaults to "ccrt" if empty
+//   - section: Section to validate - "" (both), "workload" (only workload), or "env" (only env)
 //
 // Returns:
 //   - nil if contract is valid
 //   - Error if contract parsing, schema retrieval, or validation fails
-func VerifyContractWithSchema(contract, version string) error {
-	contractMap, err := stringToMap(contract)
+func VerifyContractWithSchema(contract, version, section string) error {
+	// First, check what sections exist in the contract
+	data := Contract{}
+	yaml.Unmarshal([]byte(contract), &data)
+	hasWorkload := len(strings.TrimSpace(data.Workload)) > 0
+	hasEnv := len(strings.TrimSpace(data.Env)) > 0
+	hasWrapper := hasWorkload || hasEnv
+
+	// Validation rules for individual section validation
+	if section == "workload" || section == "env" {
+		// Rule: If wrapper format detected, reject
+		if hasWrapper {
+			if hasWorkload && hasEnv {
+				return fmt.Errorf("contract contains both env and workload sections. To validate individual sections, provide raw section content without 'env:' or 'workload:' wrappers, or use section=\"\" to validate the complete contract")
+			}
+			// Even if only one wrapper exists, reject for individual section validation
+			return fmt.Errorf("wrapper format detected. For individual section validation, provide raw section content starting with 'type: %s' (without 'env:' or 'workload:' wrapper)", section)
+		}
+	}
+
+	// Validation rule for complete contract validation
+	if section == "" {
+		// Must have both sections with wrappers
+		if !hasWorkload || !hasEnv {
+			return fmt.Errorf("complete contract validation requires both 'env:' and 'workload:' sections")
+		}
+	}
+
+	contractMap, err := stringToMap(contract, section)
 	if err != nil {
 		return fmt.Errorf("failed to convert to map %v", err)
 	}
@@ -672,56 +700,229 @@ func VerifyContractWithSchema(contract, version string) error {
 		return fmt.Errorf("error fetching contract schema")
 	}
 
-	sch, err := jsonschema.CompileString("schema.json", contractSchema)
+	// For individual section validation, create a wrapper schema
+	if section == "workload" || section == "env" {
+		return validateIndividualSection(contractStringMap, contractSchema, section)
+	}
+
+	// For complete contract validation (both sections)
+	return validateCompleteContract(contractStringMap, contractSchema)
+}
+
+// validateCompleteContract validates a complete contract with both workload and env sections.
+func validateCompleteContract(contractMap map[string]any, schemaJSON string) error {
+	sch, err := jsonschema.CompileString("schema.json", schemaJSON)
 	if err != nil {
 		return fmt.Errorf("failed to parse schema - %v", err)
 	}
 
-	if err := sch.Validate(contractStringMap); err != nil {
+	if err := sch.Validate(contractMap); err != nil {
 		return fmt.Errorf("contract validation failed - %v", err)
 	}
 
 	return nil
 }
 
+// validateIndividualSection validates a single section (workload or env) against the schema.
+// It creates a wrapper schema that references only the specific section definition.
+func validateIndividualSection(contractMap map[string]any, schemaJSON string, section string) error {
+	// Step 1: Parse the schema JSON
+	var schemaMap map[string]interface{}
+	if err := json.Unmarshal([]byte(schemaJSON), &schemaMap); err != nil {
+		return fmt.Errorf("failed to parse schema JSON - %v", err)
+	}
+
+	// Step 2: Merge all schema definitions into one place
+	mergedDefs := mergeSchemaDefinitions(schemaMap)
+
+	// Step 3: Create a wrapper schema that points to the specific section
+	wrapperSchema := createSectionWrapperSchema(section, mergedDefs)
+
+	// Step 4: Compile the wrapper schema
+	wrapperBytes, err := json.Marshal(wrapperSchema)
+	if err != nil {
+		return fmt.Errorf("failed to create wrapper schema - %v", err)
+	}
+
+	sch, err := jsonschema.CompileString("schema.json", string(wrapperBytes))
+	if err != nil {
+		return fmt.Errorf("failed to compile %s schema - %v", section, err)
+	}
+
+	// Step 5: Validate the section data
+	sectionData, ok := contractMap[section]
+	if !ok {
+		return fmt.Errorf("section '%s' not found in contract", section)
+	}
+
+	if err := sch.Validate(sectionData); err != nil {
+		return fmt.Errorf("%s section validation failed - %v", section, err)
+	}
+
+	return nil
+}
+
+// mergeSchemaDefinitions merges schema definitions from root $defs and allOf[1]/$defs.
+// The JSON schema has definitions in two locations, and we need them all in one place.
+// It also fixes references from #/allOf/1/$defs/... to #/$defs/...
+func mergeSchemaDefinitions(schemaMap map[string]interface{}) map[string]interface{} {
+	mergedDefs := make(map[string]interface{})
+
+	// Copy definitions from root $defs
+	if rootDefs, ok := schemaMap["$defs"].(map[string]interface{}); ok {
+		for k, v := range rootDefs {
+			mergedDefs[k] = v
+		}
+	}
+
+	// Copy definitions from allOf[1]/$defs and fix their internal references
+	if allOf, ok := schemaMap["allOf"].([]interface{}); ok && len(allOf) > 1 {
+		if allOfItem, ok := allOf[1].(map[string]interface{}); ok {
+			if allOfDefs, ok := allOfItem["$defs"].(map[string]interface{}); ok {
+				for k, v := range allOfDefs {
+					// Fix references so they point to the merged $defs location
+					mergedDefs[k] = fixSchemaReferences(v)
+				}
+			}
+		}
+	}
+
+	return mergedDefs
+}
+
+// createSectionWrapperSchema creates a simple schema that references a specific section definition.
+// This allows us to validate just one section (workload or env) independently.
+func createSectionWrapperSchema(section string, definitions map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"$ref":  "#/$defs/" + section,
+		"$defs": definitions,
+	}
+}
+
+// fixSchemaReferences recursively updates schema references from #/allOf/1/$defs/... to #/$defs/...
+// This is needed because we're merging definitions from allOf[1]/$defs into the root $defs.
+func fixSchemaReferences(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		result := make(map[string]interface{})
+		for k, v := range val {
+			if k == "$ref" {
+				// Fix the reference path
+				if ref, ok := v.(string); ok {
+					result[k] = strings.Replace(ref, "#/allOf/1/$defs/", "#/$defs/", 1)
+				} else {
+					result[k] = v
+				}
+			} else {
+				// Recursively fix nested references
+				result[k] = fixSchemaReferences(v)
+			}
+		}
+		return result
+	case []interface{}:
+		// Recursively fix references in arrays
+		result := make([]interface{}, len(val))
+		for i, v := range val {
+			result[i] = fixSchemaReferences(v)
+		}
+		return result
+	default:
+		return v
+	}
+}
+
 // stringToMap converts a contract YAML string to a nested map structure.
 // It parses the contract YAML containing workload, env, and optional envWorkloadSignature fields,
 // unmarshals each section, and returns a structured map representation.
 //
+// This function supports two formats:
+//  1. Wrapped format: Contract with 'env:' and 'workload:' keys (for complete contract validation)
+//  2. Raw format: Section content starting with 'type: env' or 'type: workload' (for individual section validation)
+//
 // Parameters:
 //   - contract: Contract YAML string with workload and env sections
+//   - section: Section to parse - "" (both), "workload" (only workload), or "env" (only env)
 //
 // Returns:
 //   - Map with "env", "workload", and optionally "envWorkloadSignature" keys
 //   - Error if YAML unmarshaling fails
-func stringToMap(contract string) (map[any]any, error) {
-	data := Contract{}
+func stringToMap(contract, section string) (map[any]any, error) {
+	dataMap := make(map[any]any)
 
+	// When validating a specific section, try raw format first
+	if section != "" {
+		// Try to parse as raw section format (type: env/workload at root)
+		sectionData := make(map[any]any)
+		err := yaml.Unmarshal([]byte(contract), &sectionData)
+		if err != nil {
+			return nil, err
+		}
+
+		// Check if it has a type field matching the requested section
+		if typeVal, ok := sectionData["type"]; ok {
+			if typeStr, ok := typeVal.(string); ok {
+				if typeStr == section {
+					// Valid raw format for the requested section
+					dataMap[section] = sectionData
+					return dataMap, nil
+				} else {
+					return nil, fmt.Errorf("section type mismatch: requested '%s' but contract has 'type: %s'", section, typeStr)
+				}
+			}
+		}
+
+		// If no type field or doesn't match, fall through to try wrapped format
+	}
+
+	// Try wrapped format (env: | and workload: |)
+	data := Contract{}
 	err := yaml.Unmarshal([]byte(contract), &data)
 	if err != nil {
+		// If we're validating a specific section and wrapped format fails, it's an error
+		if section != "" {
+			return nil, fmt.Errorf("invalid contract format: 'type' field not found. Expected 'type: %s'", section)
+		}
 		return nil, err
 	}
 
-	dataEnv := make(map[any]any)
-	err = yaml.Unmarshal([]byte(data.Env), &dataEnv)
-	if err != nil {
-		return nil, err
+	// Check if contract has wrapper format (env: or workload: keys)
+	hasWrapper := len(strings.TrimSpace(data.Env)) > 0 || len(strings.TrimSpace(data.Workload)) > 0
+
+	if hasWrapper {
+		// Format A: Wrapped format (env: | and workload: |)
+		// Parse env section if requested or if no specific section is specified
+		if section == "" || section == "env" {
+			dataEnv := make(map[any]any)
+			err = yaml.Unmarshal([]byte(data.Env), &dataEnv)
+			if err != nil {
+				return nil, err
+			}
+			dataMap["env"] = dataEnv
+		}
+
+		// Parse workload section if requested or if no specific section is specified
+		if section == "" || section == "workload" {
+			dataWorkload := make(map[any]any)
+			err = yaml.Unmarshal([]byte(data.Workload), &dataWorkload)
+			if err != nil {
+				return nil, err
+			}
+			dataMap["workload"] = dataWorkload
+		}
+
+		// Include signature only when validating both sections
+		if section == "" && len(data.WorkloadSignature) != 0 {
+			dataMap["envWorkloadSignature"] = data.WorkloadSignature
+		}
+	} else {
+		// No wrapper format and no valid raw format
+		if section == "" {
+			return nil, fmt.Errorf("invalid contract format: contract must contain both 'env:' and 'workload:' sections for complete validation")
+		}
+		return nil, fmt.Errorf("invalid contract format: 'type' field not found. Expected 'type: %s'", section)
 	}
 
-	dataWorkload := make(map[any]any)
-	err = yaml.Unmarshal([]byte(data.Workload), &dataWorkload)
-	if err != nil {
-		return nil, err
-	}
-
-	dataMap := make(map[any]any)
-	dataMap["env"] = dataEnv
-	dataMap["workload"] = dataWorkload
-	if len(data.WorkloadSignature) != 0 {
-		dataMap["envWorkloadSignature"] = data.WorkloadSignature
-	}
-
-	return dataMap, err
+	return dataMap, nil
 }
 
 // convertToStringkeys recursively converts a map with any-typed keys to string-keyed maps.

--- a/common/general/general_test.go
+++ b/common/general/general_test.go
@@ -375,7 +375,7 @@ func TestVerifyContractWithSchema(t *testing.T) {
 		t.Errorf("failed to read contract - %v", err)
 	}
 
-	err = VerifyContractWithSchema(contract, "")
+	err = VerifyContractWithSchema(contract, "", "")
 	if err != nil {
 		t.Errorf("schema verification failed - %v", err)
 	}
@@ -388,7 +388,7 @@ func TestVerifyContractWithSchemaInvalid(t *testing.T) {
 		t.Errorf("failed to read contract - %v", err)
 	}
 
-	err = VerifyContractWithSchema(contract, "")
+	err = VerifyContractWithSchema(contract, "", "")
 
 	assert.Error(t, err)
 }
@@ -740,7 +740,7 @@ func TestVerifyContractWithSchemaValidConfidentialContainers(t *testing.T) {
 	}
 
 	// This SHOULD pass because all required fields are present
-	err = VerifyContractWithSchema(contract, "ccco")
+	err = VerifyContractWithSchema(contract, "ccco", "")
 
 	assert.NoError(t, err, "Validation should pass when all required fields are present")
 }
@@ -753,7 +753,7 @@ func TestVerifyContractWithSchemaMissingRegoValidator(t *testing.T) {
 		t.Errorf("failed to read contract - %v", err)
 	}
 
-	err = VerifyContractWithSchema(contract, "ccco")
+	err = VerifyContractWithSchema(contract, "ccco", "")
 
 	assert.Error(t, err, "Validation should fail when regoValidator is missing")
 	assert.Contains(t, err.Error(), "regoValidator", "Error message should mention regoValidator")
@@ -767,7 +767,7 @@ func TestVerifyContractWithSchemaMissingRegoValidatorPolicy(t *testing.T) {
 		t.Errorf("failed to read contract - %v", err)
 	}
 
-	err = VerifyContractWithSchema(contract, "ccco")
+	err = VerifyContractWithSchema(contract, "ccco", "")
 
 	assert.Error(t, err, "Validation should fail when regoValidator.policy is missing")
 	assert.Contains(t, err.Error(), "policy", "Error message should mention policy")

--- a/contract/contract.go
+++ b/contract/contract.go
@@ -37,6 +37,12 @@ const (
 	contractTemplateDirPath  = "template"
 	workloadTemplateFilePath = "workload.yaml"
 	envTemplateFilePath      = "env.yaml"
+	// Section validation constants for HpcrVerifyContract.
+	// Use these when calling HpcrVerifyContract to specify which section(s) to validate.
+	SectionBoth     = ""         // Validate both workload and env sections (default, backward compatible)
+	SectionWorkload = "workload" // Validate only workload section
+	SectionEnv      = "env"      // Validate only env section
+)
 )
 
 // HPCC initdata.toml file template without sehdr bin.
@@ -301,17 +307,42 @@ func HpcrTgzEncrypted(folderPath, confidentialComputingOs, certVersion, encrypti
 // to catch errors early, before deployment. It is recommended to call this function before
 // [HpcrContractSignedEncrypted] or [HpcrContractSignedEncryptedContractExpiry].
 //
+// This function supports two validation modes:
+//
+//  1. Complete contract validation (section = "" or SectionBoth):
+//     Validates both workload and env sections together.
+//     Contract must have both 'env:' and 'workload:' wrapper keys.
+//
+//  2. Individual section validation (section = SectionWorkload or SectionEnv):
+//     Validates only the specified section independently.
+//     Contract must be in raw format (starting with 'type: workload' or 'type: env')
+//     without 'env:' or 'workload:' wrapper keys.
+//
 // Parameters:
 //   - contract: YAML contract string to validate (must contain workload and env sections)
 //   - version: Platform identifier — "ccrt" (IBM Confidential Computing Container Runtime (CCRT)),
 //     "ccrv" (IBM Confidential Computing Container Runtime for Red Hat Virtualization Solutions (CCRV)), or "ccco" (IBM Confidential Computing Container Runtime for Red Hat OpenShift (CCCO)).
 //     Defaults to "ccrt" if empty.
+//   - section: Section to validate — SectionBoth (both workload and env - default), SectionWorkload (only workload),
+//     or SectionEnv (only env). Use this for multi-persona workflows where different teams create workload
+//     and env sections separately.
 //
 // Returns:
 //   - nil if the contract is valid
 //   - Error with details about validation failures
-func HpcrVerifyContract(contract, version string) error {
-	return gen.VerifyContractWithSchema(contract, version)
+//
+// Example:
+//
+//	// Validate complete contract (both sections with wrappers)
+//	err := contract.HpcrVerifyContract(contractYAML, "ccrt", contract.SectionBoth)
+//
+//	// Validate only workload section (raw format, no wrapper)
+//	err := contract.HpcrVerifyContract(workloadYAML, "ccrt", contract.SectionWorkload)
+//
+//	// Validate only env section (raw format, no wrapper)
+//	err := contract.HpcrVerifyContract(envYAML, "ccrt", contract.SectionEnv)
+func HpcrVerifyContract(contract, version, section string) error {
+	return gen.VerifyContractWithSchema(contract, version, section)
 }
 
 // HpcrContractSignedEncrypted generates a production-ready signed and encrypted contract.
@@ -345,7 +376,7 @@ func HpcrVerifyContract(contract, version string) error {
 //   - SHA256 hash of the final signed contract (output checksum)
 //   - Error if validation, encryption, or signing fails
 func HpcrContractSignedEncrypted(contract, confidentialComputingOs, certVersion, encryptionCertificate, privateKey, password string) (string, string, string, error) {
-	err := HpcrVerifyContract(contract, confidentialComputingOs)
+	err := HpcrVerifyContract(contract, confidentialComputingOs, SectionBoth)
 	if err != nil {
 		return "", "", "", fmt.Errorf("schema verification failed - %v", err)
 	}
@@ -414,7 +445,7 @@ func HpcrContractSignedEncrypted(contract, confidentialComputingOs, certVersion,
 //   - SHA256 hash of the final signed contract (output checksum)
 //   - Error if validation, CSR generation, certificate creation, or signing fails
 func HpcrContractSignedEncryptedContractExpiry(contract, confidentialComputingOs, certVersion, encryptionCertificate, privateKey, password, cacert, caKey, csrDataStr, csrPemData string, expiryDays int) (string, string, string, error) {
-	err := HpcrVerifyContract(contract, confidentialComputingOs)
+	err := HpcrVerifyContract(contract, confidentialComputingOs, SectionBoth)
 	if err != nil {
 		return "", "", "", fmt.Errorf("schema verification failed - %v", err)
 	}

--- a/contract/contract.go
+++ b/contract/contract.go
@@ -43,7 +43,6 @@ const (
 	SectionWorkload = "workload" // Validate only workload section
 	SectionEnv      = "env"      // Validate only env section
 )
-)
 
 // HPCC initdata.toml file template without sehdr bin.
 const tomlTemplate = `

--- a/contract/contract_test.go
+++ b/contract/contract_test.go
@@ -119,7 +119,9 @@ func common(testType string) (string, string, string, string, string, error) {
 		return "", "", "", "", "", err
 	}
 
-	if testType == "TestHpcrVerifyContract" || testType == "TestHpcrVerifyContractAttestPubKey" {
+	if testType == "TestHpcrVerifyContract" || testType == "TestHpcrVerifyContractAttestPubKey" ||
+		testType == "TestHpcrVerifyContractBothSectionsWithWorkloadRequest" ||
+		testType == "TestHpcrVerifyContractBothSectionsWithEnvRequest" {
 		return contract, "", "", "", "", nil
 	} else if testType == "TestHpcrContractSignedEncrypted" {
 		return contract, privateKey, "", "", "", nil
@@ -226,7 +228,7 @@ func TestHpcrVerifyContract(t *testing.T) {
 		t.Errorf("failed to get contract - %v", err)
 	}
 
-	err = HpcrVerifyContract(contract, "")
+	err = HpcrVerifyContract(contract, "", SectionBoth)
 	if err != nil {
 		t.Errorf("failed to verify contract schema - %v", err)
 	}
@@ -239,7 +241,7 @@ func TestHpcrVerifyContractAttestPubKey(t *testing.T) {
 		t.Errorf("failed to get contract - %v", err)
 	}
 
-	err = HpcrVerifyContract(contract, "")
+	err = HpcrVerifyContract(contract, "", SectionBoth)
 	if err != nil {
 		t.Errorf("failed to verify contract schema - %v", err)
 	}
@@ -820,8 +822,94 @@ func TestHpcrContractSignedEncryptedContractExpiryInvalidPrivateKey(t *testing.T
 // Testcase to check if HpcrVerifyContract() handles invalid schema
 func TestHpcrVerifyContractInvalidSchema(t *testing.T) {
 	invalidContract := `workload: test`
-	err := HpcrVerifyContract(invalidContract, "")
+	err := HpcrVerifyContract(invalidContract, "", SectionBoth)
 	assert.Error(t, err)
+}
+
+// Testcase to verify individual workload section validation (positive case)
+func TestHpcrVerifyContractWorkloadOnly(t *testing.T) {
+	workloadContract, err := gen.ReadDataFromFile("../samples/workload_only.yaml")
+	if err != nil {
+		t.Errorf("failed to read workload contract - %v", err)
+	}
+
+	err = HpcrVerifyContract(workloadContract, "", SectionWorkload)
+	assert.NoError(t, err, "Workload-only validation should pass with raw format")
+}
+
+// Testcase to verify individual env section validation (positive case)
+func TestHpcrVerifyContractEnvOnly(t *testing.T) {
+	envContract, err := gen.ReadDataFromFile("../samples/env_only.yaml")
+	if err != nil {
+		t.Errorf("failed to read env contract - %v", err)
+	}
+
+	err = HpcrVerifyContract(envContract, "", SectionEnv)
+	assert.NoError(t, err, "Env-only validation should pass with raw format")
+}
+
+// Testcase to verify error when validating individual section with wrapper format
+func TestHpcrVerifyContractWorkloadWithWrapper(t *testing.T) {
+	// Contract with only workload wrapper
+	wrappedWorkload := `workload: |
+  type: workload
+  volumes:
+    test:
+      filesystem: ext4`
+
+	err := HpcrVerifyContract(wrappedWorkload, "", SectionWorkload)
+	assert.Error(t, err, "Should fail when wrapper format is used for individual section validation")
+	assert.Contains(t, err.Error(), "wrapper format detected", "Error should mention wrapper format")
+}
+
+// Testcase to verify error when validating individual section but contract has both sections
+func TestHpcrVerifyContractBothSectionsWithWorkloadRequest(t *testing.T) {
+	contract, _, _, _, _, err := common(t.Name())
+	if err != nil {
+		t.Errorf("failed to get contract - %v", err)
+	}
+
+	err = HpcrVerifyContract(contract, "", SectionWorkload)
+	assert.Error(t, err, "Should fail when contract has both sections but only workload is requested")
+	assert.Contains(t, err.Error(), "both env and workload sections", "Error should mention both sections")
+}
+
+// Testcase to verify error when validating individual section but contract has both sections
+func TestHpcrVerifyContractBothSectionsWithEnvRequest(t *testing.T) {
+	contract, _, _, _, _, err := common(t.Name())
+	if err != nil {
+		t.Errorf("failed to get contract - %v", err)
+	}
+
+	err = HpcrVerifyContract(contract, "", SectionEnv)
+	assert.Error(t, err, "Should fail when contract has both sections but only env is requested")
+	assert.Contains(t, err.Error(), "both env and workload sections", "Error should mention both sections")
+}
+
+// Testcase to verify error when section type mismatch
+func TestHpcrVerifyContractSectionTypeMismatch(t *testing.T) {
+	// Workload content but requesting env validation
+	workloadContract, err := gen.ReadDataFromFile("../samples/workload_only.yaml")
+	if err != nil {
+		t.Errorf("failed to read workload contract - %v", err)
+	}
+
+	err = HpcrVerifyContract(workloadContract, "", SectionEnv)
+	assert.Error(t, err, "Should fail when section type doesn't match requested section")
+	assert.Contains(t, err.Error(), "type mismatch", "Error should mention type mismatch")
+}
+
+// Testcase to verify error when complete contract validation but only one section provided
+func TestHpcrVerifyContractCompleteValidationWithOnlyWorkload(t *testing.T) {
+	wrappedWorkload := `workload: |
+  type: workload
+  volumes:
+    test:
+      filesystem: ext4`
+
+	err := HpcrVerifyContract(wrappedWorkload, "", SectionBoth)
+	assert.Error(t, err, "Should fail when complete validation requested but only one section provided")
+	assert.Contains(t, err.Error(), "both 'env:' and 'workload:' sections", "Error should mention both sections required")
 }
 
 // Testcase to check if HpcrContractTemplate() is able to return workload template content.

--- a/samples/env_only.yaml
+++ b/samples/env_only.yaml
@@ -1,0 +1,1 @@
+type: env

--- a/samples/workload_only.yaml
+++ b/samples/workload_only.yaml
@@ -1,0 +1,3 @@
+type: workload
+compose:
+  archive: kdsbfoijdfojsnbo


### PR DESCRIPTION
## Description

Adds support for validating individual workload or env sections independently in HpcrVerifyContract(). Previously the function only validated a complete contract containing both workload: and env: sections. This change introduces a section parameter and three exported constants (SectionBoth, SectionWorkload, SectionEnv) to support multi-persona workflows where the workload team and env team author their sections separately and need to validate them before assembly.

**Key changes:**

- **HpcrVerifyContract** gains a section string parameter; passing SectionBoth ("") preserves the existing behaviour.
- **VerifyContractWithSchema** similarly gains a section parameter and routes to either validateCompleteContract or validateIndividualSection.
- **validateIndividualSection** extracts the section's JSON Schema definition from the full schema (merging $defs from root and allOf[1]), builds a wrapper schema, and validates the raw section content.
- Clear error messages guide callers when the wrong format is supplied (wrapper vs raw, section mismatch, etc.).
- Two sample files samples/workload_only.yaml and samples/env_only.yaml are added for testing and documentation.
- All existing call sites **(HpcrContractSignedEncrypted, HpcrContractSignedEncryptedContractExpiry)** are updated to explicitly pass SectionBoth — no behaviour change.


## Related Issue


Fixes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactor (no functional changes)
- [ ] CI/CD or build changes

**Note: HpcrVerifyContract** has a new required section parameter — callers that previously used this function directly will need to add SectionBoth as the third argument. Internal call sites have already been updated.

## Target Platform

<!-- Which IBM Confidential Computing platform(s) does this affect? -->

- [x] HPVS (IBM Hyper Protect Virtual Servers for VPC)
- [x] CCRT (IBM Confidential Computing Container Runtime)
- [x] CCRV (IBM Confidential Computing Container Runtime for Red Hat Virtualization Solutions)
- [x] CCCO (IBM Confidential Computing Containers for Red Hat OpenShift Container Platform)
- [ ] All platforms
- [ ] Not platform-specific

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

- [x] `make test` passes
- [x] `make fmt` applied (no formatting changes needed)
- [x] New tests added for new functionality (if applicable)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added/updated GoDoc comments for public functions
- [ ] I have updated documentation (README, docs/README.md) if needed
- [x] All new and existing tests pass (`make test`)
- [ ] I have verified there are no breaking changes (or documented them above)
