### PR TITLE
chore(deps): golang upgraded to 1.26.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
 env:
   # Currently no way to detect automatically
   DEFAULT_BRANCH: main
-  GO_VERSION: 1.26.1 # renovate: datasource=golang-version depName=golang
+  GO_VERSION: 1.26.4 # renovate: datasource=golang-version depName=golang
   NODE_VERSION: 25.5.0
 
 jobs:

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,10 @@
 module github.com/ibm-hyper-protect/contract-go/v2
 
-go 1.26.1
+go 1.26.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
-github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Description

- removed github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 from go.mod as it is not imported by any source file
- updated go version 1.26.4

## Related Issue

<!-- Link the issue this PR addresses. Use "Fixes #123" to auto-close the issue on merge. -->

Fixes #248 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactor (no functional changes)
- [x] CI/CD or build changes

## Target Platform

<!-- Which IBM Confidential Computing platform(s) does this affect? -->

- [ ] HPVS (IBM Hyper Protect Virtual Servers for VPC)
- [ ] CCRT (IBM Confidential Computing Container Runtime)
- [ ] CCRV (IBM Confidential Computing Container Runtime for Red Hat Virtualization Solutions)
- [ ] CCCO (IBM Confidential Computing Containers for Red Hat OpenShift Container Platform)
- [ ] All platforms
- [x] Not platform-specific

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

- [x] `make test` passes
- [ ] `make fmt` applied (no formatting changes needed)
- [ ] New tests added for new functionality (if applicable)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [ ] I have added/updated GoDoc comments for public functions
- [ ] I have updated documentation (README, docs/README.md) if needed
- [x] All new and existing tests pass (`make test`)
- [x] I have verified there are no breaking changes (or documented them above)
